### PR TITLE
Fix "INSTALL_LOC" in version file

### DIFF
--- a/GameData/RationalResources/Version/RationalResources.version
+++ b/GameData/RationalResources/Version/RationalResources.version
@@ -9,7 +9,7 @@
 	{
 		"USERNAME":"JadeOfMaar",
 		"REPOSITORY":"https://github.com/JadeOfMaar/RationalResources",
-		"ALLOW_PRE_RELEASE":true,
+		"ALLOW_PRE_RELEASE":true
 	},
 	"VERSION":
 	{
@@ -27,7 +27,9 @@
 	"INSTALL_LOC":
 	{
 		"NAME": "Rational Resources",
-		"PATH": "RationalResources/Version/RationalResources.version"
+		"PATH": "",
+		"DIRECTORY": "RationalResources/Version/",
+		"FILE": "RationalResources.version"
 	}
 }
 


### PR DESCRIPTION
See https://github.com/Galileo88/JNSQ/issues/15.
The `INSTALL_LOC` property in the version file is not correct atm.
This causes a warning from MADLAD despite it being correctly installed.

The path to the version file has to be split into `DIRECTORY` and `FILE`.
I also removed a misplaced comma, which made the version file invalid JSON.

Closes #5