### PR TITLE
Add the N2 NTR as a subtype of the reducing propellant NTR

### DIFF
--- a/GameData/RationalResourcesParts/Parts/Engines/NTR.cfg
+++ b/GameData/RationalResourcesParts/Parts/Engines/NTR.cfg
@@ -1,5 +1,5 @@
 // Reducing propellants:
-// hydrogen, ammonia, and methane
+// hydrogen, ammonia, nitrogen, and methane
 
 // Oxidizing propellants:
 // oxygen, water, and carbon dioxide
@@ -528,6 +528,41 @@ PART
 					{
 						key = 0 400
 						key = 1 92
+						key = 2 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Nitrogen
+			title = Liquid Nitrogen
+			primaryColor = PeacockBlue
+			secondaryColor = PeacockBlue
+			defaultSubtypePriority = 0
+			descriptionSummary = The engine consumes <color="yellow">LqdNitrogen</color>.<br>Nitrogen as a propellant may be very niche and abysmal in terms of Isp, but it is common in planetary crusts, atmospheres, oceans, and exospheres.
+			descriptionDetail = <b>Thrust:</b> 7.56 kN ASL / <color="yellow">40 kN</color> Vac.<br><b>Isp:</b> 60 s ASL / <color="yellow">261 s</color> Vac.
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleEnginesFX
+					engineID = mainEngine
+				}
+				DATA
+				{
+					maxThrust = 40
+					PROPELLANT
+					{
+						name = LqdNitrogen
+						ratio = 1
+						DrawGauge = True
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = 0 261
+						key = 1 60
 						key = 2 0.001
 					}
 				}


### PR DESCRIPTION
As discussed earlier. Values for Isp are from atomic rockets (http://www.projectrho.com/public_html/rocket/enginelist2.php#solidcore), using ratio of H2 to N2 exhaust velocities to determine N2 Isp. I didn't want to do the math for thrust, so I made up 40 kn vac thrust to incentivize use of harder-to-procure propellants. Tested on my machine, works great.