### PR TITLE
Enhanced support for several mods

### DIFF
--- a/Extras/RR_RCSFamily.cfg
+++ b/Extras/RR_RCSFamily.cfg
@@ -1,0 +1,881 @@
+// Opt-In: Stock [also covered by separate patches]
+
+// @PART[RCSBlock_v2,linearRcs]:BEFORE[RationalResourcesRCS]:NEEDS[Squad]
+// {
+//   %RationalResourcesRCSMP = True
+// }
+//
+// @PART[vernierEngine]:BEFORE[RationalResourcesRCS]:NEEDS[Squad]
+// {
+//   %RationalResourcesRCSLFO = True
+// }
+
+// Opt-In: Restock Plus [also covered by separate Extras patch]
+
+// @PART[restock-rcs*]:BEFORE[RationalResourcesRCS]:NEEDS[ReStockPlus]
+// {
+//   %RationalResourcesRCSMP = True
+// }
+
+// Opt-In: Near Future Spacecraft
+
+@PART[rcsblock-aero-5way-1,rcsblock-orbital-*]:BEFORE[RationalResourcesRCS]:NEEDS[NearFutureSpacecraft]
+{
+  %RationalResourcesRCSMP = True
+}
+
+// Opt-In: Near Future Launch Vehicles [excludes "integrated" RCS as NFLV has its own conditional patches for those]
+
+@PART[nflv-rcs-aero-heavy-1,nflv-rcs-heavy-1x-1,nflv-rcs-heavy-4x-1]:BEFORE[RationalResourcesRCS]:NEEDS[NearFutureLaunchVehicles]
+{
+  %RationalResourcesRCSMP = True
+}
+
+@PART[nflv-rcs-aero-heavy-2,nflv-rcs-heavy-1x-2,nflv-rcs-heavy-4x-2]:BEFORE[RationalResourcesRCS]:NEEDS[NearFutureLaunchVehicles]
+{
+  %RationalResourcesRCSLFO = True
+}
+
+// Opt-In: Near Future Aeronautics
+
+@PART[nfa-rcsblister-1]:BEFORE[RationalResourcesRCS]:NEEDS[NearFutureAeronautics]
+{
+  %RationalResourcesRCSMP = True
+}
+
+// Opt-In: Mark IV Spaceplane System
+
+@PART[mk4rcsblister-2,mk4cockpit-shoulder-2]:BEFORE[RationalResourcesRCS]:NEEDS[MarkIVSystem]
+{
+  %RationalResourcesRCSMP = True
+}
+
+// Opt-In: Kerbal Reusability Expansion
+
+@PART[SmallCapsuleEngineRCS]:BEFORE[RationalResourcesRCS]:NEEDS[KerbalReusabilityExpansion]
+{
+  %RationalResourcesRCSMP = True
+}
+
+@PART[HotGasThruster-*]:BEFORE[RationalResourcesRCS]:NEEDS[KerbalReusabilityExpansion]
+{
+  %RationalResourcesRCSLFO = True
+}
+
+// CRP: Monopropellant (main block)
+
+@PART[*]:HAS[#RationalResourcesRCSMP[True],@MODULE[ModuleRCSFX]]:FOR[RationalResourcesRCS]:NEEDS[B9PartSwitch,CommunityResourcePack,!ClassicStock]
+{
+  IspVac = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,0[1, ]$ // get vac Isp number
+  IspASL = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,1[1, ]$ // get ASL Isp number
+  IspMult = #$IspVac$ // set numerator for div operation
+  @IspMult /= 240 // denominator, the highest vac Isp number among stock parts
+
+  // precision sequence to keep div number at 2dp and not let it be 12+dp
+  @IspMult += 0.005
+  @IspMult *= 100
+  @IspMult = #$IspMult[0,.]$ // regex truncate, unknown behavior but used in RO
+  @IspMult /= 100
+
+  // set and scale reference Isp numbers
+  IspVacAtm = 70
+  IspASLAtm = 35
+  @IspVacAtm *= #$IspMult$
+  @IspASLAtm *= #$IspMult$
+
+  IspVacH2 = 272
+  IspASLH2 = 136
+  @IspVacH2 *= #$IspMult$
+  @IspASLH2 *= #$IspMult$
+
+  IspVacN2 = 73
+  IspASLN2 = 36.5
+  @IspVacN2 *= #$IspMult$
+  @IspASLN2 *= #$IspMult$
+
+  IspVacAr = 52
+  IspASLAr = 26
+  @IspVacAr *= #$IspMult$
+  @IspASLAr *= #$IspMult$
+
+  IspVacXe = 28
+  IspASLXe = 14
+  @IspVacXe *= #$IspMult$
+  @IspASLXe *= #$IspMult$
+
+  IspVacCH4 = 105
+  IspASLCH4 = 52.5
+  @IspVacCH4 *= #$IspMult$
+  @IspASLCH4 *= #$IspMult$
+
+  IspVacNH3 = 96
+  IspASLNH3 = 48
+  @IspVacNH3 *= #$IspMult$
+  @IspASLNH3 *= #$IspMult$
+
+  IspVacCO2 = 61
+  IspASLCO2 = 30.5
+  @IspVacCO2 *= #$IspMult$
+  @IspASLCO2 *= #$IspMult$
+
+  @description ^= :$: <br><color="green">RCS can accept other fuels.</color>
+  MODULE
+  {
+    name = ModuleB9PartSwitch
+    moduleID = RCS
+    switcherDescription = RCS Mode
+    switcherDescriptionPlural = RCS Modes
+    switchInFlight = True
+    SUBTYPE
+    {
+      name = MonoPropellant
+      title = MonoPropellant
+      primaryColor = ResourceColorMonoPropellant
+      secondaryColor = ResourceColorMonoPropellant
+      descriptionDetail = #Uses MonoPropellant.<br><b>Isp:</b> $/IspASL$ / $/IspVac$s.
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleRCSFX
+        }
+        DATA
+        {
+          thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+          resourceName = MonoPropellant
+          PROPELLANT
+          {
+            name = MonoPropellant
+            ratio = 1
+            resourceFlowMode = STAGE_PRIORITY_FLOW
+          }
+          atmosphereCurve
+          {
+            key = #0 $/IspVac$
+            key = #1 $/IspASL$
+            key = 4 0.001
+          }
+        }
+      }
+    }
+    SUBTYPE
+    {
+      name = IntakeAtm
+      title = IntakeAtm
+      primaryColor = LightGrey
+      secondaryColor = LightGrey
+      descriptionDetail = #Uses IntakeAtm.<br><b>Isp:</b> <color="yellow">$/IspASLAtm$ / $/IspVacAtm$</color>s.
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleRCSFX
+        }
+        DATA
+        {
+          thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+          resourceName = IntakeAtm
+          PROPELLANT
+          {
+            name = IntakeAtm
+            ratio = 1
+            resourceFlowMode = STAGE_PRIORITY_FLOW
+          }
+          atmosphereCurve
+          {
+            key = #0 $/IspVacAtm$
+            key = #1 $/IspASLAtm$
+            key = 4 0.001
+          }
+        }
+      }
+    }
+    SUBTYPE
+    {
+      name = LqdHydrogen
+      title = LqdHydrogen
+      primaryColor = ResourceColorLqdHydrogen
+      secondaryColor = ResourceColorLqdHydrogen
+      descriptionDetail = #Uses Liquid Hydrogen.<br><b>Isp:</b> <color="yellow">$/IspASLH2$ / $/IspVacH2$</color>s.
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleRCSFX
+        }
+        DATA
+        {
+          thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+          resourceName = LqdHydrogen
+          PROPELLANT
+          {
+            name = LqdHydrogen
+            ratio = 1
+            resourceFlowMode = STAGE_PRIORITY_FLOW
+          }
+          atmosphereCurve
+          {
+            key = #0 $/IspVacH2$
+            key = #1 $/IspASLH2$
+            key = 4 0.001
+          }
+        }
+      }
+    }
+    SUBTYPE
+    {
+      name = LqdNitrogen
+      title = LqdNitrogen
+      primaryColor = PeacockBlue
+      secondaryColor = PeacockBlue
+      descriptionDetail = #Uses Liquid Nitrogen.<br><b>Isp:</b> <color="yellow">$/IspASLN2$ / $/IspVacN2$</color>s.
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleRCSFX
+        }
+        DATA
+        {
+          thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+          resourceName = LqdNitrogen
+          PROPELLANT
+          {
+            name = LqdNitrogen
+            ratio = 1
+            resourceFlowMode = STAGE_PRIORITY_FLOW
+          }
+          atmosphereCurve
+          {
+            key = #0 $/IspVacN2$
+            key = #1 $/IspASLN2$
+            key = 4 0.001
+          }
+        }
+      }
+    }
+    SUBTYPE
+    {
+      name = ArgonGas
+      title = ArgonGas
+      primaryColor = Blush
+      secondaryColor = Blush
+      descriptionDetail = #Uses Argon gas.<br><b>Isp:</b> <color="yellow">$/IspASLAr$ / $/IspVacAr$</color>s.
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleRCSFX
+        }
+        DATA
+        {
+          thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+          resourceName = ArgonGas
+          PROPELLANT
+          {
+            name = ArgonGas
+            ratio = 1
+            resourceFlowMode = STAGE_PRIORITY_FLOW
+          }
+          atmosphereCurve
+          {
+            key = #0 $/IspVacAr$
+            key = #1 $/IspASLAr$
+            key = 4 0.001
+          }
+        }
+      }
+    }
+    SUBTYPE
+    {
+      name = XenonGas
+      title = XenonGas
+      primaryColor = ResourceColorXenonGas
+      secondaryColor = ResourceColorXenonGas
+      descriptionDetail = #Uses Xenon gas.<br><b>Isp:</b> <color="yellow">$/IspASLXe$ / $/IspVacXe$</color>s.
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleRCSFX
+        }
+        DATA
+        {
+          thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+          resourceName = XenonGas
+          PROPELLANT
+          {
+            name = XenonGas
+            ratio = 1
+            resourceFlowMode = STAGE_PRIORITY_FLOW
+          }
+          atmosphereCurve
+          {
+            key = #0 $/IspVacXe$
+            key = #1 $/IspASLXe$
+            key = 4 0.001
+          }
+        }
+      }
+    }
+    SUBTYPE
+    {
+      name = LqdMethane
+      title = LqdMethane
+      primaryColor = ResourceColorLqdMethane
+      secondaryColor = ResourceColorLqdMethane
+      descriptionDetail = #Uses Liquid Methane.<br><b>Isp:</b> <color="yellow">$/IspASLCH4$ / $/IspVacCH4$</color>s.
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleRCSFX
+        }
+        DATA
+        {
+          thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+          resourceName = LqdMethane
+          PROPELLANT
+          {
+            name = LqdMethane
+            ratio = 1
+            resourceFlowMode = STAGE_PRIORITY_FLOW
+          }
+          atmosphereCurve
+          {
+            key = #0 $/IspVacCH4$
+            key = #1 $/IspASLCH4$
+            key = 4 0.001
+          }
+        }
+      }
+    }
+    SUBTYPE
+    {
+      name = LqdAmmonia
+      title = LqdAmmonia
+      primaryColor = BurntRed
+      secondaryColor = BurntRed
+      descriptionDetail = #Uses Liquid Ammonia.<br><b>Isp:</b> <color="yellow">$/IspASLNH3$ / $/IspVacNH3$</color>s.
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleRCSFX
+        }
+        DATA
+        {
+          thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+          resourceName = LqdAmmonia
+          PROPELLANT
+          {
+            name = LqdAmmonia
+            ratio = 1
+            resourceFlowMode = STAGE_PRIORITY_FLOW
+          }
+          atmosphereCurve
+          {
+            key = #0 $/IspVacNH3$
+            key = #1 $/IspASLNH3$
+            key = 4 0.001
+          }
+        }
+      }
+    }
+    SUBTYPE
+    {
+      name = LqdCO2
+      title = LqdCO2
+      primaryColor = WarmGrey
+      secondaryColor = WarmGrey
+      descriptionDetail = #Uses Liquid Carbon Dioxide.<br><b>Isp:</b> <color="yellow">$/IspASLCO2$ / $/IspVacCO2$</color>s.
+      MODULE
+      {
+        IDENTIFIER
+        {
+          name = ModuleRCSFX
+        }
+        DATA
+        {
+          thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+          resourceName = LqdCO2
+          PROPELLANT
+          {
+            name = LqdCO2
+            ratio = 1
+            resourceFlowMode = STAGE_PRIORITY_FLOW
+          }
+          atmosphereCurve
+          {
+            key = #0 $/IspVacCO2$
+            key = #1 $/IspASLCO2$
+            key = 4 0.001
+          }
+        }
+      }
+    }
+  }
+}
+
+// CRP: Monopropellant (cleanup)
+
+@PART[*]:HAS[#RationalResourcesRCSMP[True],@MODULE[ModuleRCSFX]]:FOR[RationalResourcesRCS]:NEEDS[B9PartSwitch,CommunityResourcePack,!ClassicStock]
+{
+  !IspASL = nope
+  !IspVac = nope
+  !IspMult = nope
+
+  !IspVacAtm = nope
+  !IspASLAtm = nope
+
+  !IspVacH2 = nope
+  !IspASLH2 = nope
+
+  !IspVacN2 = nope
+  !IspASLN2 = nope
+
+  !IspVacAr = nope
+  !IspASLAr = nope
+
+  !IspVacXe = nope
+  !IspASLXe = nope
+
+  !IspVacCH4 = nope
+  !IspASLCH4 = nope
+
+  !IspVacNH3 = nope
+  !IspASLNH3 = nope
+
+  !IspVacCO2 = nope
+  !IspASLCO2 = nope
+}
+
+// CRP: LFO (main block)
+
+@PART[*]:HAS[#RationalResourcesRCSLFO[True],@MODULE[ModuleRCSFX]]:FOR[RationalResourcesRCS]:NEEDS[B9PartSwitch,CommunityResourcePack,!ClassicStock]
+{
+  IspVac = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,0[1, ]$ // get vac Isp number
+	IspASL = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,1[1, ]$ // get ASL Isp number
+  IspMult = #$IspVac$ // set numerator for div operation
+  @IspMult /= 260 // denominator, the highest vac Isp number among stock parts
+
+  // precision sequence to keep div number at 2dp and not let it be 12+dp
+  @IspMult += 0.005
+  @IspMult *= 100
+  @IspMult = #$IspMult[0,.]$ // regex truncate, unknown behavior but used in RO
+  @IspMult /= 100
+
+	IspVacH2 = 380
+	IspASLH2 = 152
+  @IspVacH2 *= #$IspMult$
+  @IspASLH2 *= #$IspMult$
+
+	IspVacCH4 = 300
+	IspASLCH4 = 170
+  @IspVacCH4 *= #$IspMult$
+  @IspASLCH4 *= #$IspMult$
+
+	@description ^= :$: <br><color="green">RCS can accept other fuels.</color>
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = RCS
+		switcherDescription = RCS Mode
+		switcherDescriptionPlural = RCS Modes
+		switchInFlight = True
+		SUBTYPE
+		{
+			name = LFO
+			title = Kerolox
+			primaryColor = ResourceColorLiquidFuel
+			secondaryColor = ResourceColorOxidizer
+			descriptionDetail = #Uses LiquidFuel + Oxidizer.<br><b>Isp:</b> $/IspASL$ / $/IspVac$s.
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$ // thrust will change if the Isp is changed and thrusterPower is not re-declared
+					PROPELLANT
+					{
+						name = LiquidFuel
+						ratio = 0.45
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 0.55
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVac$
+						key = #1 $/IspASL$
+						key = 5 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Hydrolox
+			title = Hydrolox
+			primaryColor = ResourceColorLqdHydrogen
+			secondaryColor = ResourceColorOxidizer
+			descriptionDetail = #Uses LqdHydrogen + Oxidizer.<br><b>Isp:</b> <color="yellow">$/IspASLH2$ / $/IspVacH2$</color>s.
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+					PROPELLANT
+					{
+						name = LqdHydrogen
+						ratio = 1.5
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 0.1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacH2$
+						key = #1 $/IspASLH2$
+						key = 5 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Methalox
+			title = Methalox
+			primaryColor = PurpleyPink
+			secondaryColor = ResourceColorOxidizer
+			descriptionDetail = #Uses LqdMethane + Oxidizer.<br><b>Isp:</b> <color="yellow">$/IspASLCH4$ / $/IspVacCH4$</color>s.
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+					PROPELLANT
+					{
+						name = LqdMethane
+						ratio = 3
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacCH4$
+						key = #1 $/IspASLCH4$
+						key = 5 0.001
+					}
+				}
+			}
+		}
+	}
+}
+
+// CRP: LFO (cleanup)
+
+@PART[*]:HAS[#RationalResourcesRCSLFO[True],@MODULE[ModuleRCSFX]]:FOR[RationalResourcesRCS]:NEEDS[B9PartSwitch,CommunityResourcePack,!ClassicStock]
+{
+  !IspVac = nope
+	!IspASL = nope
+  !IspMult = nope
+
+	!IspVacH2 = nope
+	!IspASLH2 = nope
+
+	!IspVacCH4 = nope
+	!IspASLCH4 = nope
+}
+
+// WBI Classic Stock: Monopropellant (main block)
+
+@PART[*]:HAS[#RationalResourcesRCSMP[True],@MODULE[ModuleRCSFX]]:FOR[RationalResourcesRCS]:NEEDS[B9PartSwitch,ClassicStock]
+{
+  IspASL = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,1[1, ]$ // get ASL Isp number
+	IspVac = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,0[1, ]$ // get vac Isp number
+	IspMult = #$IspVac$ // set numerator for div operation
+	@IspMult /= 240 // denominator, the highest vac Isp number among stock parts
+
+	// precision sequence to keep div number at 2dp and not let it be 12+dp
+	@IspMult += 0.005
+	@IspMult *= 100
+	@IspMult = #$IspMult[0,.]$ // regex truncate, unknown behavior but used in RO
+	@IspMult /= 100
+
+	// set and scale reference Isp numbers
+	IspVacAtm = 70
+	IspASLAtm = 35
+	@IspVacAtm *= #$IspMult$
+	@IspASLAtm *= #$IspMult$
+
+	IspVacPLM = 272
+	IspASLPLM = 136
+	@IspVacPLM *= #$IspMult$
+	@IspASLPLM *= #$IspMult$
+
+	IspVacN2O = 171.4
+	IspASLN2O = 85.7
+	@IspVacN2O *= #$IspMult$
+	@IspASLN2O *= #$IspMult$
+
+	IspVacXe = 28
+	IspASLXe = 14
+	@IspVacXe *= #$IspMult$
+	@IspASLXe *= #$IspMult$
+
+	IspVacRPT = 105
+	IspASLRPT = 52.5
+	@IspVacRPT *= #$IspMult$
+	@IspASLRPT *= #$IspMult$
+
+	@description ^= :$: <br><color="green">RCS can accept other fuels.</color>
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = RCS
+		switcherDescription = RCS Mode
+		switcherDescriptionPlural = RCS Modes
+		switchInFlight = True
+		SUBTYPE
+		{
+			name = MonoPropellant
+			title = MonoPropellant
+			primaryColor = ResourceColorMonoPropellant
+			secondaryColor = ResourceColorMonoPropellant
+			descriptionDetail = #Uses MonoPropellant.<br><b>Isp:</b> $/IspASL$ / $/IspVac$s.
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+					resourceName = MonoPropellant
+					PROPELLANT
+					{
+						name = MonoPropellant
+						ratio = 1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVac$
+						key = #1 $/IspASL$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = CompressedAtmosphere
+			title = CompressedAtmosphere
+			primaryColor = WarmGrey
+			secondaryColor = WarmGrey
+			descriptionDetail = #Uses Compressed Atmosphere.<br><b>Isp:</b> <color="yellow">$/IspASLAtm$ / $/IspVacAtm$</color>s.
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+					resourceName = Atmosphere
+					PROPELLANT
+					{
+						name = CompressedAtmosphere
+						ratio = 1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacAtm$
+						key = #1 $/IspASLAtm$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Propellium
+			title = Propellium
+			primaryColor = Lightblue
+			secondaryColor = Lightblue
+			descriptionDetail = #Uses Propellium gas.<br><b>Isp:</b> <color="yellow">$/IspASLPLM$ / $/IspVacPLM$</color>s.
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+					resourceName = Propellium
+					PROPELLANT
+					{
+						name = Propellium
+						ratio = 1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacPLM$
+						key = #1 $/IspASLPLM$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Nitronite
+			title = Nitronite
+			primaryColor = ResourceColorMonoPropellant
+			secondaryColor = ResourceColorMonoPropellant
+			descriptionDetail = #Uses Nitronite gas.<br><b>Isp:</b> <color="yellow">$/IspASLN2O$ / $/IspVacN2O$</color>s.
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+					resourceName = Nitronite
+					PROPELLANT
+					{
+						name = Nitronite
+						ratio = 1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacN2O$
+						key = #1 $/IspASLN2O$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = XenonGas
+			title = XenonGas
+			primaryColor = ResourceColorXenonGas
+			secondaryColor = ResourceColorXenonGas
+			descriptionDetail = #Uses Xenon gas.<br><b>Isp:</b> <color="yellow">$/IspASLXe$ / $/IspVacXe$</color>s.
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+					resourceName = XenonGas
+					PROPELLANT
+					{
+						name = XenonGas
+						ratio = 1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacXe$
+						key = #1 $/IspASLXe$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Raptium
+			title = Raptium
+			primaryColor = PurpleyPink
+			secondaryColor = PurpleyPink
+			descriptionDetail = #Uses Raptium gas.<br><b>Isp:</b> <color="yellow">$/IspASLRPT$ / $/IspVacRPT$</color>s.
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/MODULE[ModuleRCSFX]/thrusterPower$
+					resourceName = Raptium
+					PROPELLANT
+					{
+						name = Raptium
+						ratio = 1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacRPT$
+						key = #1 $/IspASLRPT$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+	}
+}
+
+// WBI Classic Stock: Monopropellant (cleanup)
+
+@PART[*]:HAS[#RationalResourcesRCSMP[True],@MODULE[ModuleRCSFX]]:FOR[RationalResourcesRCS]:NEEDS[B9PartSwitch,ClassicStock]
+{
+  !IspASL = nope
+  !IspVac = nope
+  !IspMult = nope
+
+  !IspVacAtm = nope
+  !IspASLAtm = nope
+
+  !IspVacPLM = nope
+  !IspASLPLM = nope
+
+  !IspVacN2O = nope
+  !IspASLN2O = nope
+
+  !IspVacXe = nope
+  !IspASLXe = nope
+
+  !IspVacRPT = nope
+  !IspASLRPT = nope
+}

--- a/GameData/RationalResourcesParts/CRP/Converter_Opt-in_Default.cfg
+++ b/GameData/RationalResourcesParts/CRP/Converter_Opt-in_Default.cfg
@@ -1,7 +1,7 @@
 @PART:HAS[#RRConverter[Set]]:NEEDS[!KerbalismDefault]:FOR[RationalResourcesParts]
 {
 	@RRConverter = isSet
-	
+
 	+MODULE[ModuleResourceConverter]:HAS[#ConverterName[Lf+Ox]]
 	{
 		@ConverterName = Kerolox B // using moles
@@ -240,7 +240,7 @@
 			@ResourceName = Oxygen
 			@Ratio = 22.69504 // 10
 		}
-		
+
 		@OUTPUT_RESOURCE:HAS[#ResourceName[Oxidizer]]
 		{
 			@ResourceName = Carbon
@@ -397,6 +397,26 @@
 			@ResourceName = Silicates
 			@Ratio = 0.0609 // 1
 		}
+	}
+	+MODULE[ModuleResourceConverter]:HAS[#ConverterName[Lf+Ox]:NEEDS[KerbalHealth]
+	{
+		@ConverterName = Lead Extractor
+		@StartActionName = Start ISRU [Lead Extractor]
+		@StopActionName = Stop ISRU [Lead Extractor]
+		@ToggleActionName = Toggle ISRU [Lead Extractor]
+		Tag = RR
+		@INPUT_RESOURCE:HAS[#ResourceName[Ore]]
+		{
+			@ResourceName = MetalOre
+			@Ratio = 0.03921830769 // Same input rate by mass as alumina splitter
+		}
+		@OUTPUT_RESOURCE:HAS[#ResourceName[LiquidFuel]]
+		{
+			@ResourceName = Lead
+			@Ratio = 0.00899185185 // 10:1 input/output ratio by mass
+			%DumpExcess = False
+		}
+		!OUTPUT_RESOURCE:HAS[#ResourceName[Oxidizer]] {}
 	}
 	@MODULE[ModuleResourceConverter]:HAS[#Tag[RR]],*
 	{

--- a/GameData/RationalResourcesParts/CRP/FFT.cfg
+++ b/GameData/RationalResourcesParts/CRP/FFT.cfg
@@ -11,6 +11,7 @@
 		}
 	}
 }
+
 @PART[imaging-spectrometer-01]:NEEDS[FarFutureTechnologies]
 {
 	@MODULE[ModuleProfilingScanner]
@@ -21,10 +22,48 @@
 		}
 	}
 }
+
 @PART[atmosphere-scoop-01]:NEEDS[FarFutureTechnologies]
 {
 	@MODULE[ModuleResourceHarvester]:HAS[#ResourceName[LqdHydrogen]]
 	{
 		@ResourceName = Hydrogen
+	}
+}
+
+@PART[fft-nuclear-smelter-375-1]:NEEDS[FarFutureTechnologies]
+{
+	+MODULE[ModuleSystemHeatConverter]:HAS[#moduleID[nswConverter]]
+	{
+		@moduleID = nswConverterRR
+		@ConverterName = Nuclear Salt Water (RR)
+    @StartActionName = Start Smelter [NSW] (RR)
+    @StopActionName = Stop Smelter [NSW] (RR)
+    @ToggleActionName = Toggle Smelter [NSW] (RR)
+		@INPUT_RESOURCE:HAS[#ResourceName[Ore]]
+		{
+			@ResourceName = Water
+			@Ratio = 5
+		}
+	}
+	+MODULE[ModuleSystemHeatConverter]:HAS[#moduleID[ablatorConverter]]
+	{
+		@moduleID = ablatorConverterRR
+		@ConverterName = Refurbish Ablator (RR)
+    @StartActionName = Start Refurbishing [Ablator] (RR)
+    @StopActionName = Stop Refurbishing [Ablator] (RR)
+    @ToggleActionName = Toggle Refurbishing [Ablator] (RR)
+		// Carbon + Water mix, with ratios scaled from Blacksmith patch
+		@INPUT_RESOURCE:HAS[#ResourceName[Ore]]
+		{
+			@ResourceName = Water
+			@Ratio = 0.00424117647
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Carbon
+			Ratio = 0.00011176471
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
 	}
 }

--- a/GameData/RationalResourcesParts/CRP/NFElectrical.cfg
+++ b/GameData/RationalResourcesParts/CRP/NFElectrical.cfg
@@ -1,0 +1,31 @@
+@PART[nuclear-recycler-25]:NEEDS[NearFutureElectrical]
+{
+  +MODULE[ModuleResourceConverter]:HAS[#ConverterName[Uranium?Extractor]]
+	{
+		@ConverterName = Uraninite Enricher
+		@StartActionName = Start Uraninite Enricher
+		@StopActionName = Stop Uraninite Enricher
+		@ToggleActionName = Toggle Uraninite Enricher
+		@INPUT_RESOURCE:HAS[#ResourceName[Ore]]
+		{
+			@ResourceName = Uraninite
+		}
+		@OUTPUT_RESOURCE:HAS[#ResourceName[EnrichedUranium]]
+		{
+			@Ratio *= 10 // arbitrary
+		}
+	}
+}
+
+@PART[MiniDrill,RadialDrill]:NEEDS[NearFutureElectrical]
+{
+  +MODULE[ModuleResourceHarvester],0
+	{
+		@ResourceName = Uraninite
+		@ConverterName = Uraninite Harvester
+		@StartActionName = Start Uraninite Harvester
+		@StopActionName = Stop Uraninite Harvester
+		@ToggleActionName = Toggle Uraninite Harvester
+		// @HarvestThreshold = 0.025
+	}
+}

--- a/GameData/RationalResourcesParts/CRP/NFElectrical.cfg
+++ b/GameData/RationalResourcesParts/CRP/NFElectrical.cfg
@@ -9,11 +9,12 @@
 		@INPUT_RESOURCE:HAS[#ResourceName[Ore]]
 		{
 			@ResourceName = Uraninite
+      @Ratio /= 10
 		}
-		@OUTPUT_RESOURCE:HAS[#ResourceName[EnrichedUranium]]
-		{
-			@Ratio *= 10 // arbitrary
-		}
+		// @OUTPUT_RESOURCE:HAS[#ResourceName[EnrichedUranium]]
+		// {
+		// 	@Ratio *= 10
+		// }
 	}
 }
 

--- a/GameData/RationalResourcesParts/CRP/Squad_ConvertOTrons_Default.cfg
+++ b/GameData/RationalResourcesParts/CRP/Squad_ConvertOTrons_Default.cfg
@@ -9,7 +9,7 @@
 		@CoreShutdownTemp = 4000
 		@MaxCoolant = 200
 	}
-	
+
 	@MODULE[ModuleResourceConverter]:HAS[#ConverterName[Lf+Ox]]
 	{
 		@TemperatureModifier
@@ -29,7 +29,7 @@
 			key = 500 0.1 0 0
 			key = 1000 1.0 0 0
 			key = 1250 0.1 0 0
-			key = 3000 0 0 0 
+			key = 3000 0 0 0
 		}
 		@INPUT_RESOURCE:HAS[#ResourceName[Ore]]
 		{
@@ -282,7 +282,7 @@
 			@ResourceName = Oxygen
 			@Ratio = 22.69504 // 10
 		}
-		
+
 		@OUTPUT_RESOURCE:HAS[#ResourceName[Oxidizer]]
 		{
 			@ResourceName = Carbon
@@ -436,6 +436,25 @@
 			@Ratio = 0.0609 // 1
 		}
 	}
+	+MODULE[ModuleResourceConverter],0:NEEDS[KerbalHealth]
+	{
+		@ConverterName = Lead Extractor
+		@StartActionName = Start ISRU [Lead Extractor]
+		@StopActionName = Stop ISRU [Lead Extractor]
+		@ToggleActionName = Toggle ISRU [Lead Extractor]
+		@INPUT_RESOURCE:HAS[#ResourceName[Ore]]
+		{
+			@ResourceName = MetalOre
+			@Ratio = 0.03921830769 // Same input rate by mass as alumina splitter
+		}
+		@OUTPUT_RESOURCE:HAS[#ResourceName[LiquidFuel]]
+		{
+			@ResourceName = Lead
+			@Ratio = 0.00899185185 // 10:1 output/input ratio by mass
+			%DumpExcess = False
+		}
+		!OUTPUT_RESOURCE:HAS[#ResourceName[Oxidizer]] {}
+	}
 }
 
 // Downscale throughput in small Convert-O-Trons
@@ -462,7 +481,7 @@
 		@CoreShutdownTemp = 3000
 		@MaxCoolant = 60
 	}
-	
+
 	@MODULE[ModuleResourceConverter],*
 	{
 		@TemperatureModifier


### PR DESCRIPTION
- Added opt-in RCS system from #21. I commented out the opt-in code for stock parts to avoid any conflicts with existing patches.
- Near Future Electrical: added a converter to the Nuclear Recycler to enrich Uraninite (instead of Ore) into EnrichedUranium; added a Uraninite harvester to stock drills. 
- KerbalHealth: added a converter to stock and opt-in ISRU parts to extract Lead from MetalOre.
- Far Future Technologies: added converters to the nuclear smelter for nuclear salt water production and ablator refurbishment, using RR resources instead of Ore.