### PR TITLE
ISRU for DeepFreeze Glykerol, KerbalHealth RadiationShielding; Blacksmith enhancements

### DIFF
--- a/Extras/RR_ScienceLabBlacksmith.cfg
+++ b/Extras/RR_ScienceLabBlacksmith.cfg
@@ -664,3 +664,22 @@ PARTUPGRADE:NEEDS[RationalResourcesParts]
 		}
 	}
 }
+
+// If System Heat converters extra is installed, tell B9PartSwitch to use the correct module
+
+@PART[Large_Crewed_Lab]:NEEDS[RationalResourcesParts,SystemHeatConverters]:FOR[RRBlacksmith]
+{
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[Blacksmith]]
+	{
+		@SUBTYPE[Work*]
+		{
+			@MODULE
+			{
+				@IDENTIFIER[ModuleResourceConverter]
+				{
+					@name = ModuleSystemHeatConverter
+				}
+			}
+		}
+	}
+}

--- a/Extras/RR_ScienceLabBlacksmith.cfg
+++ b/Extras/RR_ScienceLabBlacksmith.cfg
@@ -671,7 +671,7 @@ PARTUPGRADE:NEEDS[RationalResourcesParts]
 {
 	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[Blacksmith]]
 	{
-		@SUBTYPE[Work*]
+		@SUBTYPE[Work*],*
 		{
 			@MODULE
 			{

--- a/Extras/RR_ScienceLabBlacksmith.cfg
+++ b/Extras/RR_ScienceLabBlacksmith.cfg
@@ -27,7 +27,7 @@ PARTUPGRADE:NEEDS[RationalResourcesParts]
 }
 
 // Heatshields refill Ablator
-@PART:HAS[@MODULE[ModuleAblator]:HAS[#ablativeResource[Ablator]]]:NEEDS[RationalResourcesParts]
+@PART:HAS[@MODULE[ModuleAblator]:HAS[#ablativeResource[Ablator]]]:NEEDS[RationalResourcesParts]:FOR[RRBlacksmith]
 {
 	@description ^= :$: <br><color="green">This part can be refilled.</color>
 	MODULE
@@ -170,7 +170,7 @@ PARTUPGRADE:NEEDS[RationalResourcesParts]
 	}
 }
 
-@PART:HAS[@MODULE[ModuleAblator]:HAS[#ablativeResource[Ablator]],@RESOURCE[Ablator]:HAS[#maxAmount[>200]]]:NEEDS[RationalResourcesParts]
+@PART:HAS[@MODULE[ModuleAblator]:HAS[#ablativeResource[Ablator]],@RESOURCE[Ablator]:HAS[#maxAmount[>200]]]:NEEDS[RationalResourcesParts]:FOR[RRBlacksmith]
 {
 	// maxAmount 200 from stock 1.25m heatshield
 	// Increase converter rates for bigger heatshields
@@ -212,7 +212,7 @@ PARTUPGRADE:NEEDS[RationalResourcesParts]
 }
 
 // Solid rockets (re)fill SolidFuel
-@PART:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[SolidFuel]]]:NEEDS[RationalResourcesParts]
+@PART:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[SolidFuel]]]:NEEDS[RationalResourcesParts]:FOR[RRBlacksmith]
 {
 	@description ^= :$: <br><color="green">This part can be refilled.</color>
 	MODULE
@@ -394,7 +394,7 @@ PARTUPGRADE:NEEDS[RationalResourcesParts]
 	}
 }
 
-@PART:HAS[@MODULE[ModuleEngines*],@RESOURCE[SolidFuel]:HAS[#maxAmount[>2600]]]:NEEDS[RationalResourcesParts]
+@PART:HAS[@MODULE[ModuleEngines*],@RESOURCE[SolidFuel]:HAS[#maxAmount[>2600]]]:NEEDS[RationalResourcesParts]:FOR[RRBlacksmith]
 {
 	// maxAmount 2600 from stock Kickback SRB
 	// Increase converter rates for bigger SRBs
@@ -437,7 +437,7 @@ PARTUPGRADE:NEEDS[RationalResourcesParts]
 
 
 // Equip stock science lab with RR Blacksmith
-@PART[Large_Crewed_Lab]:NEEDS[RationalResourcesParts]
+@PART[Large_Crewed_Lab]:NEEDS[RationalResourcesParts]:FOR[RRBlacksmith]
 {
 	MODULE
 	{

--- a/GameData/RationalResourcesParts/CRP/Converter_Opt-in_Default.cfg
+++ b/GameData/RationalResourcesParts/CRP/Converter_Opt-in_Default.cfg
@@ -418,6 +418,37 @@
 		}
 		!OUTPUT_RESOURCE:HAS[#ResourceName[Oxidizer]] {}
 	}
+	+MODULE[ModuleResourceConverter]:HAS[#ConverterName[Lf+Ox]:NEEDS[DeepFreeze]
+	{
+		@ConverterName = Glykerol // Glycerol, C3H8O3
+		@StartActionName = Start ISRU [Glykerol]
+		@StopActionName = Stop ISRU [Glykerol]
+		@ToggleActionName = Toggle ISRU [Glykerol]
+		Tag = RR
+		@INPUT_RESOURCE:HAS[#ResourceName[Ore]]
+		{
+			@ResourceName = Water
+			@Ratio = 0.00010867519
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Carbon
+			Ratio = 0.00002587720
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+		@OUTPUT_RESOURCE:HAS[#ResourceName[LiquidFuel]]
+		{
+			@ResourceName = Glykerol
+			@Ratio = 0.00011574074 // calibrated for 5 units every 12 hours
+			%DumpExcess = False
+		}
+		@OUTPUT_RESOURCE:HAS[#ResourceName[Oxidizer]]
+		{
+			@ResourceName = Oxygen
+			@Ratio = 0.01711235940
+			%DumpExcess = True // Byproduct
+		}
+	}
 	@MODULE[ModuleResourceConverter]:HAS[#Tag[RR]],*
 	{
 		@INPUT_RESOURCE:HAS[~ResourceName[ElectricCharge]],*

--- a/GameData/RationalResourcesParts/CRP/KerbalHealth.cfg
+++ b/GameData/RationalResourcesParts/CRP/KerbalHealth.cfg
@@ -1,0 +1,76 @@
+// Produce RadiationShielding via EpL or Blacksmith
+// A non-transferable resource resembling polyethylene (C2H4)
+
+// EpL:
+
+EL_ResourceRecipe:NEEDS[ExtraplanetaryLaunchpads,KerbalHealth]
+{
+  name = RadiationShielding
+  Resources
+  {
+    Carbon = 24.022
+    Hydrogen = 4.032
+  }
+}
+
+// Blacksmith:
+
+@PART:HAS[@RESOURCE[RadiationShielding]]:NEEDS[RRBlacksmith,KerbalHealth]:AFTER[KerbalHealth]
+{
+	@description ^= :$: <br><color="green">Shielding producible in-situ via Blacksmith.</color>
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = Install Radiation Shielding
+		StartActionName = Start Radiation Shielding
+		StopActionName = Stop Radiation Shielding
+		AutoShutdown = true
+		EfficiencyBonus = 1
+		INPUT_RESOURCE
+		{
+			ResourceName = RRWork
+			Ratio = 0.2
+			FlowMode = ALL_VESSEL
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ThermalPower
+			Ratio = 0.1
+			FlowMode = ALL_VESSEL
+		}
+    INPUT_RESOURCE
+		{
+			ResourceName = Carbon
+			Ratio = 0.06931767645
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+    INPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 271.77841431347
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = RadiationShielding
+			Ratio = 0.0017 // Same mass rate as Blacksmith Ablator
+			DumpExcess = false
+			FlowMode = NO_FLOW
+		}
+	}
+}
+
+@PART:HAS[@RESOURCE[RadiationShielding]:HAS[#maxAmount[>1]]]:NEEDS[RRBlacksmith,KerbalHealth]:AFTER[KerbalHealth]
+{
+	@MODULE:HAS[#ConverterName[Install?Radiation?Shielding]]
+	{
+		@INPUT_RESOURCE,*
+		{
+			@Ratio *= #$../../RESOURCE[RadiationShielding]/maxAmount$
+		}
+		@OUTPUT_RESOURCE
+		{
+			@Ratio *= #$../../RESOURCE[RadiationShielding]/maxAmount$
+		}
+	}
+}

--- a/GameData/RationalResourcesParts/CRP/KerbalHealth.cfg
+++ b/GameData/RationalResourcesParts/CRP/KerbalHealth.cfg
@@ -22,8 +22,8 @@ EL_ResourceRecipe:NEEDS[ExtraplanetaryLaunchpads,KerbalHealth]
 	{
 		name = ModuleResourceConverter
 		ConverterName = Install Radiation Shielding
-		StartActionName = Start Radiation Shielding
-		StopActionName = Stop Radiation Shielding
+		StartActionName = Start Rad Shielding Production
+		StopActionName = Stop Rad Shielding Production
 		AutoShutdown = true
 		EfficiencyBonus = 1
 		INPUT_RESOURCE

--- a/GameData/RationalResourcesParts/CRP/Squad_ConvertOTrons_Default.cfg
+++ b/GameData/RationalResourcesParts/CRP/Squad_ConvertOTrons_Default.cfg
@@ -455,6 +455,36 @@
 		}
 		!OUTPUT_RESOURCE:HAS[#ResourceName[Oxidizer]] {}
 	}
+	+MODULE[ModuleResourceConverter],0:NEEDS[DeepFreeze]
+	{
+		@ConverterName = Glykerol // Glycerol, C3H8O3
+		@StartActionName = Start ISRU [Glykerol]
+		@StopActionName = Stop ISRU [Glykerol]
+		@ToggleActionName = Toggle ISRU [Glykerol]
+		@INPUT_RESOURCE:HAS[#ResourceName[Ore]]
+		{
+			@ResourceName = Water
+			@Ratio = 0.00010867519
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Carbon
+			Ratio = 0.00002587720
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+		@OUTPUT_RESOURCE:HAS[#ResourceName[LiquidFuel]]
+		{
+			@ResourceName = Glykerol
+			@Ratio = 0.00011574074 // calibrated for 5 units every 12 hours
+			%DumpExcess = False
+		}
+		@OUTPUT_RESOURCE:HAS[#ResourceName[Oxidizer]]
+		{
+			@ResourceName = Oxygen
+			@Ratio = 0.01711235940
+			%DumpExcess = True // Byproduct
+		}
+	}
 }
 
 // Downscale throughput in small Convert-O-Trons


### PR DESCRIPTION
Additional support for KerbalHealth: ISRU for RadiationShielding, a non-transferable resource resembling polyethylene (C2H4).
- Adds an EpL recipe if EpL is installed.
- Adds a Blacksmith recipe if Blacksmith is installed.
- Adds :FOR[RRBlacksmith] to the main Blacksmith patch to facilitate detection.

Support for DeepFreeze: ISRU for Glykerol, a cryoprotectant resource based on glycerol (C3H8O3). Adds a conversion to stock and opt-in converters if DeepFreeze is installed.

If SystemHeatConverters was installed, B9PartSwitch would throw warnings as it attempted to apply the different Blacksmith work levels to the replaced stock resource converter module. This change adds detection for SHC and tells B9PS to apply work levels to ModuleSystemHeatConverter if needed.