### PR TITLE
Quick and dirty fix for issue #25 (Kerbalism support)

### DIFF
--- a/GameData/RationalResourcesParts/CRP/00_Kerbalism.cfg
+++ b/GameData/RationalResourcesParts/CRP/00_Kerbalism.cfg
@@ -1,4 +1,4 @@
-Profile:NEEDS[KerbalismDefault]
+Profile
 {
 	name = KerbalismSupport
 	modname = Rational Resources Parts
@@ -110,9 +110,11 @@ Profile:NEEDS[KerbalismDefault]
 		modifier = _SplitterAl2O3
 		input = ElectricCharge@30
 		input = Alumina@0.2562
-		output = Metal@0.1002
+		// Disabled because Metal is added through a conditional MM patch, which isn't supported by Kerbalism
+		// see https://github.com/JadeOfMaar/RationalResources/issues/25
+		//output = Metal@0.1002
 		output = Oxygen@113.4752
-		dump_valve = Metal,Oxygen
+		dump_valve = Oxygen //,Metal
 	}
 	Process
 	{
@@ -136,10 +138,13 @@ Profile:NEEDS[KerbalismDefault]
 		input = Spodumene@0.06
 		output = Lithium@0.013
 		// output = Aluminum@0.0097
-		output = Metal@0.00346
-		output = Silicates@0.0609
-		dump_valve = Lithium,Metal,Silicates,Lithium&Metal,Lithium&Silicates,Metal&Silicates
 		
+		// Disabled because Metal is added through a conditional MM patch, which isn't supported by Kerbalism
+		// see https://github.com/JadeOfMaar/RationalResources/issues/25
+		// output = Metal@0.00346
+		output = Silicates@0.0609
+		// dump_valve = Lithium,Metal,Silicates,Lithium&Metal,Lithium&Silicates,Metal&Silicates
+		dump_valve = Lithium,Silicates,Lithium&Silicates
 	}
 	Process
 	{
@@ -177,9 +182,12 @@ Profile:NEEDS[KerbalismDefault]
 		output = Water@0.1802
 		output = XenonGas@0.0144
 		output = ArgonGas@0.8957
-		output = MetalOre@0.0129
+		// Disabled because MetalOre is added through a conditional MM patch, which isn't supported by Kerbalism
+		// see https://github.com/JadeOfMaar/RationalResources/issues/25
+		//output = MetalOre@0.0129
 		output = Oxygen@68.0851
-		dump_valve = XenonGas&ArgonGas&MetalOre&Oxygen,Water&XenonGas&ArgonGas&MetalOre,XenonGas&ArgonGas&MetalOre,Water&ArgonGas&MetalOre&Oxygen,Water&XenonGas&MetalOre&Oxygen,Water&XenonGas&ArgonGas&Oxygen
+		// dump_valve = XenonGas&ArgonGas&MetalOre&Oxygen,Water&XenonGas&ArgonGas&MetalOre,XenonGas&ArgonGas&MetalOre,Water&ArgonGas&MetalOre&Oxygen,Water&XenonGas&MetalOre&Oxygen,Water&XenonGas&ArgonGas&Oxygen
+		dump_valve = XenonGas&ArgonGas&Oxygen,Water&XenonGas&ArgonGas,XenonGas&ArgonGas,Water&ArgonGas&Oxygen,Water&XenonGas&Oxygen,Water&XenonGas&ArgonGas&Oxygen
 	}
 	
 	// - Compressor/Freezer converters
@@ -308,6 +316,12 @@ Profile:NEEDS[KerbalismDefault]
 }
 
 // Define pseudo-resources used by proccess controllers
+RESOURCE_DEFINITION:NEEDS[Kerbalism,ProfileDefault]
+{
+	name = _MRER
+	density = 0.0
+	isVisible = false
+}
 RESOURCE_DEFINITION:NEEDS[Kerbalism,ProfileDefault]
 {
 	name = _AmmoniaBrew


### PR DESCRIPTION
- Removed the `:NEEDS[KerbalismDefault]` applied to the `Profile` node : Kerbalism load profiles before MM runs, so profiles can't use MM syntax (and using it will cause errors, as the MM syntax won't be stripped out from the nodes/values names read by Kerbalism)
- Added missing `RESOURCE_DEFINITION` for the `_MRER` process
- Removed `Metal` and `MetalOre` processes outputs. See https://github.com/JadeOfMaar/RationalResources/issues/25