### PR TITLE
VentralDrill, restock-apu CCK, cryotanks CCK

### DIFF
--- a/GameData/RationalResources/CCK/Categories.cfg
+++ b/GameData/RationalResources/CCK/Categories.cfg
@@ -17,7 +17,7 @@
 {
 	@tags ^= :$: cck-rr:
 }
-@PART[MiniISRU|ISRU|MiniDrill|RadialDrill|FuelCell|FuelCellArray]:NEEDS[RationalResourcesParts]
+@PART[MiniISRU|ISRU|MiniDrill|RadialDrill|FuelCell|FuelCellArray|restock-apu-*]:NEEDS[RationalResourcesParts]
 {
 	@tags ^= :$: cck-rr:
 }
@@ -26,10 +26,6 @@
 	@tags ^= :$: cck-rr:
 }
 @PART[SMX_*Generator|SMX_*AtmCondenser|SMX_*Drill|SMX_*Pump|SMX_*Ore?ank|SMX_*Driver|SMX_*ISRU*]:NEEDS[MiningExpansion]
-{
-	@tags ^= :$: cck-rr:
-}
-@PART[hydrogen-*]:NEEDS[CryoTanks]
 {
 	@tags ^= :$: cck-rr:
 }

--- a/GameData/RationalResourcesParts/CRP/Drill_Opt-in_00.cfg
+++ b/GameData/RationalResourcesParts/CRP/Drill_Opt-in_00.cfg
@@ -9,3 +9,10 @@
 {
 	RRHarvester = Set
 }
+
+
+// VentralDrill
+@PART[VentralISRUDrill]:NEEDS[VentralDrill]:BEFORE[RationalResourcesParts]
+{
+	RRHarvester = Set
+}


### PR DESCRIPTION
* Opt-in VentralISRUDrill from the VentralDrill
 * add restock-apu to the RR-category
 * remove cryotanks from the RR-category, because cryotanks mod add the same b9 switchers also to the stock tanks, so probably there is nothing RR-special in these tanks