### PR TITLE
Converter Patch Fix

### DIFF
--- a/GameData/RationalResourcesKerbalism/01_Opt-in_Converters.cfg
+++ b/GameData/RationalResourcesKerbalism/01_Opt-in_Converters.cfg
@@ -294,24 +294,24 @@
 		capacity = 1
 		@capacity *= #$/RRPower$
 	}
-	MODULE
-	{
-		name = ProcessController
-		resource = _LeadExtractor
-		title = KH Lead Extractor
-		Tag = RR
-		capacity = 1
-		@capacity *= #$/RRPower$
-	}
-	MODULE
-	{
-		name = ProcessController
-		resource = _SplitterAl2O3
-		title = Alumina Splitter
-		Tag = RR
-		capacity = 1
-		@capacity *= #$/RRPower$
-	}
+	// MODULE
+	// {
+	//	name = ProcessController
+	//	resource = _LeadExtractor
+	//	title = KH Lead Extractor
+	//	Tag = RR
+	//	capacity = 1
+	//	@capacity *= #$/RRPower$
+	// }
+	// MODULE
+	// {
+	//	name = ProcessController
+	//	resource = _SplitterAl2O3
+	//	title = Alumina Splitter
+	//	Tag = RR
+	//	capacity = 1
+	//	@capacity *= #$/RRPower$
+	// }
 	MODULE
 	{
 		name = ProcessController
@@ -330,15 +330,15 @@
 		capacity = 1
 		@capacity *= #$/RRPower$
 	}
-	MODULE
-	{
-		name = ProcessController
-		resource = _SplitterHydrates
-		title = Hydrates Splitter
-		Tag = RR
-		capacity = 1
-		@capacity *= #$/RRPower$
-	}
+	// MODULE
+	// {
+	//	name = ProcessController
+	//	resource = _SplitterHydrates
+	//	title = Hydrates Splitter
+	//	Tag = RR
+	//	capacity = 1
+	//	@capacity *= #$/RRPower$
+	// }
 	MODULE
 	{
 		name = ProcessController
@@ -348,15 +348,15 @@
 		capacity = 1
 		@capacity *= #$/RRPower$
 	}
-	MODULE
-	{
-		name = ProcessController
-		resource = _SplitterSpod
-		title = Spodumene Splitter
-		Tag = RR
-		capacity = 1
-		@capacity *= #$/RRPower$
-	}
+	// MODULE
+	// {
+	//	name = ProcessController
+	//	resource = _SplitterSpod
+	//	title = Spodumene Splitter
+	//	Tag = RR
+	//	capacity = 1
+	//	@capacity *= #$/RRPower$
+	// }
 
 	@MODULE[Configure]
 	{

--- a/GameData/RationalResourcesKerbalism/Squad_ConvertOTrons.cfg
+++ b/GameData/RationalResourcesKerbalism/Squad_ConvertOTrons.cfg
@@ -292,30 +292,30 @@
 		Tag = RR
 		capacity = 1
 	}
-	MODULE
-	{
-		name = ProcessController
-		resource = _LeadExtractor
-		title = KH Lead Extractor
-		Tag = RR
-		capacity = 1
-	}
-	MODULE
-	{
-		name = ProcessController
-		resource = _SplitterAl2O3
-		title = Alumina Splitter
-		Tag = RR
-		capacity = 1
-	}
-	MODULE
-	{
-		name = ProcessController
-		resource = _SplitterCO2
-		title = Carbon Dioxide Splitter
-		Tag = RR
-		capacity = 1
-	}
+	// MODULE
+	// {
+	//	name = ProcessController
+	//	resource = _LeadExtractor
+	//	title = KH Lead Extractor
+	//	Tag = RR
+	//	capacity = 1
+	// }
+	// MODULE
+	// {
+	//	name = ProcessController
+	//	resource = _SplitterAl2O3
+	//	title = Alumina Splitter
+	//	Tag = RR
+	//	capacity = 1
+	// }
+	// MODULE
+	// {
+	//	name = ProcessController
+	//	resource = _SplitterCO2
+	//	title = Carbon Dioxide Splitter
+	//	Tag = RR
+	//	capacity = 1
+	// }
 	MODULE
 	{
 		name = ProcessController
@@ -324,14 +324,14 @@
 		Tag = RR
 		capacity = 1
 	}
-	MODULE
-	{
-		name = ProcessController
-		resource = _SplitterHydrates
-		title = Hydrates Splitter
-		Tag = RR
-		capacity = 1
-	}
+	// MODULE
+	// {
+	//	name = ProcessController
+	//	resource = _SplitterHydrates
+	//	title = Hydrates Splitter
+	//	Tag = RR
+	//	capacity = 1
+	// }
 	MODULE
 	{
 		name = ProcessController
@@ -340,14 +340,14 @@
 		Tag = RR
 		capacity = 1
 	}
-	MODULE
-	{
-		name = ProcessController
-		resource = _SplitterSpod
-		title = Spodumene Splitter
-		Tag = RR
-		capacity = 1
-	}
+	//MODULE
+	// {
+	//	name = ProcessController
+	//	resource = _SplitterSpod
+	//	title = Spodumene Splitter
+	//	Tag = RR
+	//	capacity = 1
+	// }
 
 	@MODULE[Configure]
 	{


### PR DESCRIPTION
Currently, some of the converter options are commented out in the patches- but only partially.
This caused buggy converter options that could not be turned off, removed from the part, and did not do the conversions they were meant to do on all ISRU converter units.
This simply completely comments out those options, eliminating the bug.