### PR TITLE
Convertors for Metals

### DIFF
--- a/GameData/RationalResources/CRP/zKerbalism.cfg
+++ b/GameData/RationalResources/CRP/zKerbalism.cfg
@@ -51,6 +51,16 @@
 		rate = 0.0025
 		ec_rate = 1.0
 	}
+	MODULE
+	{
+		name = Harvester
+		title = MetallicOre Excavation
+		type = 0
+		resource = MetallicOre
+		min_abundance = 0.02
+		rate = 0.0025
+		ec_rate = 1.0
+	}
 	
 	@MODULE[Configure]
 	{
@@ -135,6 +145,23 @@
 			RESOURCE
 			{
 				name = MetalOre
+				amount = 0
+				maxAmount = 50
+			}
+		}
+		SETUP
+		{
+			name = MetallicOre Extraction
+			desc = Extract <b>MetallicOre</b> from the surface.
+			MODULE
+			{
+				type = Harvester
+				id_field = resource
+				id_value = MetallicOre
+			}
+			RESOURCE
+			{
+				name = MetallicOre
 				amount = 0
 				maxAmount = 50
 			}

--- a/GameData/RationalResources/CRP/zTankTypes.cfg
+++ b/GameData/RationalResources/CRP/zTankTypes.cfg
@@ -192,6 +192,28 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 		unitsPerVolume = 1
 	}
 }
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
+{
+	name = RR_MetallicOre
+	tankMass = 0
+	tankCost = 0
+	RESOURCE
+	{
+		name = MetallicOre
+		unitsPerVolume = 1
+	}
+}
+B9_TANK_TYPE:NEEDS[B9PartSwitch]
+{
+	name = RR_Metals
+	tankMass = 0
+	tankCost = 0
+	RESOURCE
+	{
+		name = Metals
+		unitsPerVolume = 1
+	}
+}
 B9_TANK_TYPE:NEEDS[B9PartSwitch,ExtraplanetaryLaunchpads]
 {
 	name = RR_RocketParts

--- a/GameData/RationalResourcesCompanion/CRP/Opt-in_ConvertOTrons.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/Opt-in_ConvertOTrons.cfg
@@ -378,7 +378,7 @@
 		@ToggleActionName = Toggle ISRU [Lead Extractor]
 		INPUT_RESOURCE
 		{
-			ResourceName = MetalOre
+			ResourceName = MetallicOre
 			Ratio = 0.03921830769 // Same input rate by mass as alumina splitter
 			FlowMode = STAGE_PRIORITY_FLOW
 		}
@@ -519,7 +519,7 @@
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Water
-			Ratio = 0.1802 // 1
+			Ratio = 0.209 // 1
 			FlowMode = STAGE_PRIORITY_FLOW
 			DumpExcess = True
 		}
@@ -539,22 +539,15 @@
 		}
 		OUTPUT_RESOURCE
 		{
-			ResourceName = MetalOre
-			Ratio = 0.0129 // 3
-			FlowMode = STAGE_PRIORITY_FLOW
-			DumpExcess = True
-		}
-		OUTPUT_RESOURCE
-		{
 			ResourceName = MetallicOre
-			Ratio = 0.06098
+			Ratio = 0.0381
 			FlowMode = STAGE_PRIORITY_FLOW
 			DumpExcess = True
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Oxygen
-			Ratio = 68.0851 // 3
+			Ratio = 21 // 3
 			FlowMode = STAGE_PRIORITY_FLOW
 			DumpExcess = True
 		}

--- a/GameData/RationalResourcesCompanion/CRP/Opt-in_OreTanks.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/Opt-in_OreTanks.cfg
@@ -43,13 +43,29 @@
 		}
 		SUBTYPE
 		{
+			name = MetallicOre
+			tankType = RR_MetallicOre
+			title = MetallicOre
+			primaryColor = BrownishGrey
+			secondaryColor = BrownishGrey
+		}
+		SUBTYPE
+		{
+			name = Metals
+			tankType = RR_Metals
+			title = Metals
+			primaryColor = Gunmetal
+			secondaryColor = Gunmetal
+		}
+		SUBTYPEE:NEEDS[ExtraplanetaryLaunchpads]
+		{
 			name = MetalOre
 			tankType = RR_MetalOre
 			title = MetalOre
 			primaryColor = BrownishGrey
 			secondaryColor = BrownishGrey
 		}
-		SUBTYPE
+		SUBTYPEE:NEEDS[ExtraplanetaryLaunchpads|SimpleConstruction]
 		{
 			name = Metal
 			tankType = RR_Metal

--- a/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
@@ -257,6 +257,28 @@
 				unitsPerT = 1600 // 1
 			}
 		}
+		TANK_TYPE_OPTION
+		{
+			name = MetallicOre
+			dryDensity = 0.1089
+			costMultiplier = 1.0
+			RESOURCE
+			{
+				name = MetallicOre
+				unitsPerT = 1600 // 0.2
+			}
+		}
+		TANK_TYPE_OPTION
+		{
+			name = Metals
+			dryDensity = 0.1089
+			costMultiplier = 1.0
+			RESOURCE
+			{
+				name = Metals
+				unitsPerT = 8000 // 1
+			}
+		}
 		// TANK_TYPE_OPTION
 		// {
 			// name = RocketParts

--- a/GameData/RationalResourcesCompanion/CRP/RR_Freezer-Heaters.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/RR_Freezer-Heaters.cfg
@@ -268,7 +268,7 @@
 	{
 		@INPUT_RESOURCE,0
 		{
-			@ResourceName = MetalOre
+			@ResourceName = MetallicOre
 		}
 	}
 }

--- a/GameData/RationalResourcesCompanion/CRP/Squad_ConvertOTrons_Default.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/Squad_ConvertOTrons_Default.cfg
@@ -92,7 +92,7 @@
 	{
 		@INPUT_RESOURCE,0
 		{
-			@ResourceName = MetalOre
+			@ResourceName = MetallicOre
 		}
 	}
 }

--- a/GameData/RationalResourcesCompanion/CRP/WBIOmniconverters.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/WBIOmniconverters.cfg
@@ -644,7 +644,7 @@ OMNICONVERTER:NEEDS[WildBlueTools]
 	OUTPUT_RESOURCE
 	{
 		ResourceName = Water
-		Ratio = 0.1802 // 1
+		Ratio = 0.209 // 1
 		FlowMode = STAGE_PRIORITY_FLOW
 		DumpExcess = True
 	}
@@ -664,22 +664,15 @@ OMNICONVERTER:NEEDS[WildBlueTools]
 	}
 	OUTPUT_RESOURCE
 	{
-		ResourceName = MetalOre
-		Ratio = 0.0129 // 3
-		FlowMode = STAGE_PRIORITY_FLOW
-		DumpExcess = True
-	}
-	OUTPUT_RESOURCE
-	{
 		ResourceName = MetallicOre
-		Ratio = 0.06098
+		Ratio = 0.0381
 		FlowMode = STAGE_PRIORITY_FLOW
 		DumpExcess = True
 	}
 	OUTPUT_RESOURCE
 	{
 		ResourceName = Oxygen
-		Ratio = 68.0851 // 3
+		Ratio = 21 // 3
 		FlowMode = STAGE_PRIORITY_FLOW
 		DumpExcess = True
 	}

--- a/GameData/RationalResourcesKerbalism/00_Kerbalism.cfg
+++ b/GameData/RationalResourcesKerbalism/00_Kerbalism.cfg
@@ -186,35 +186,21 @@ Profile
 		output = Hydrogen@2246.941
 		dump_valve = CarbonMonoxide,Hydrogen
 	}
-	// Process
-	// {
-		// name = HydratesSplitter // Original
-		// title = Hydrates Splitter
-		// Tag = RR
-		// modifier = _SplitterHydrates
-		// input = ElectricCharge@0.0042
-		// input = Hydrates@0.3014
-		// output = Water@0.1802
-		// output = XenonGas@0.0144
-		// output = ArgonGas@0.8957
-		// output = MetalOre@0.0129
-		// output = Oxygen@68.0851
-		// dump_valve = XenonGas&ArgonGas&MetalOre&Oxygen,Water&XenonGas&ArgonGas&MetalOre,XenonGas&ArgonGas&MetalOre,Water&ArgonGas&MetalOre&Oxygen,Water&XenonGas&MetalOre&Oxygen,Water&XenonGas&ArgonGas&Oxygen
-	// }
-	Process
-	{
-		name = HydratesSplitter // Temp stable version without Metal
-		title = Hydrates Splitter
-		Tag = RR
-		modifier = _SplitterHydrates
-		input = ElectricCharge@0.0042
-		input = Hydrates@0.3014
-		output = Water@0.1802
-		output = XenonGas@0.0144
-		output = ArgonGas@0.8957
-		output = Oxygen@68.0851
-		dump_valve = XenonGas&ArgonGas&Oxygen,Water&XenonGas&ArgonGas,XenonGas&ArgonGas,Water&ArgonGas&Oxygen,Water&XenonGas&Oxygen,Water&XenonGas&ArgonGas&Oxygen
-	}
+	 Process
+	 {
+		 name = HydratesSplitter // Original
+		 title = Hydrates Splitter
+		 Tag = RR
+		 modifier = _SplitterHydrates
+		 input = ElectricCharge@0.0042
+		 input = Hydrates@0.3014
+		 output = Water@0.209
+		 output = XenonGas@0.0144
+		 output = ArgonGas@0.8957
+		 output = MetallicOre@0.0381
+		 output = Oxygen@21
+		 dump_valve = XenonGas&ArgonGas&MetallicOre&Oxygen,Water&XenonGas&ArgonGas&MetallicOre,XenonGas&ArgonGas&MetallicOre,Water&ArgonGas&MetallicOre&Oxygen,Water&XenonGas&MetallicOre&Oxygen,Water&XenonGas&ArgonGas&Oxygen
+	 }
 	Process
 	{
 		name = MonaziteSplitter
@@ -420,6 +406,32 @@ Profile
 		input = LqdOxygen@0.28
 		output = Oxygen@226.95
 	}
+	Process
+	{
+		name = ECHeatedMetalSmelter
+		title = Metals Smelter
+		Tag = RR
+		modifier = _ECHeatedMetalSmelter
+		input = ElectricCharge@0.0042
+		input =   MetallicOre@0.086
+		input =    Hydrogen@179.334
+		output =       Metals@0.03817
+		output =        Water@0.13548
+		dump_valve = Water
+		// 90% of ore converted to Metals
+		//  5% of mass is lost to space
+		//  5% of ore was water
+	}
+	Process
+	{
+		name = ECHeatedMetalRemelter
+		title = Metals Remelter
+		Tag = RR
+		modifier = _ECHeatedMetalRemelter
+		input = ElectricCharge@0.0042
+		input = ScrapMetal@0.0901
+		output = Metals@0.0462
+	}
 }
 
 // Define pseudo-resources used by proccess controllers
@@ -520,6 +532,18 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	name = _SplitterSpod
+	density = 0.0
+	isVisible = false
+}
+RESOURCE_DEFINITION
+{
+	name = _ECHeatedMetalSmelter
+	density = 0.0
+	isVisible = false
+}
+RESOURCE_DEFINITION
+{
+	name = _ECHeatedMetalRemelter
 	density = 0.0
 	isVisible = false
 }

--- a/GameData/RationalResourcesKerbalism/00_Kerbalism.cfg
+++ b/GameData/RationalResourcesKerbalism/00_Kerbalism.cfg
@@ -422,16 +422,6 @@ Profile
 		//  5% of mass is lost to space
 		//  5% of ore was water
 	}
-	Process
-	{
-		name = ECHeatedMetalRemelter
-		title = Metals Remelter
-		Tag = RR
-		modifier = _ECHeatedMetalRemelter
-		input = ElectricCharge@0.0042
-		input = ScrapMetal@0.0901
-		output = Metals@0.0462
-	}
 }
 
 // Define pseudo-resources used by proccess controllers
@@ -538,12 +528,6 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	name = _ECHeatedMetalSmelter
-	density = 0.0
-	isVisible = false
-}
-RESOURCE_DEFINITION
-{
-	name = _ECHeatedMetalRemelter
 	density = 0.0
 	isVisible = false
 }

--- a/GameData/RationalResourcesKerbalism/01_Opt-in_Converters.cfg
+++ b/GameData/RationalResourcesKerbalism/01_Opt-in_Converters.cfg
@@ -346,15 +346,6 @@
 		capacity = 1
 		@capacity *= #$/RRPower$
 	}
-	MODULE
-	{
-		name = ProcessController
-		resource = _ECHeatedMetalRemelter
-		title = Metal Remelter
-		Tag = RR
-		capacity = 1
-		@capacity *= #$/RRPower$
-	}
 	
 	// = = RR Default Splitters = =
 	
@@ -543,18 +534,6 @@
 				type = ProcessController
 				id_field = resource
 				id_value = _ECHeatedMetalSmelter
-			}
-		}
-		SETUP
-		{
-			name = Metals Remelter
-			desc = Recycle <b>ScrapMetal</b> into <b>Metals</b>.
-			tech = advScienceTech
-			MODULE
-			{
-				type = ProcessController
-				id_field = resource
-				id_value = _ECHeatedMetalRemelter
 			}
 		}
 		

--- a/GameData/RationalResourcesKerbalism/01_Opt-in_Converters.cfg
+++ b/GameData/RationalResourcesKerbalism/01_Opt-in_Converters.cfg
@@ -337,6 +337,24 @@
 	//	capacity = 1
 	//	@capacity *= #$/RRPower$
 	// }
+	MODULE
+	{
+		name = ProcessController
+		resource = _ECHeatedMetalSmelter
+		title = Metal Smelter
+		Tag = RR
+		capacity = 1
+		@capacity *= #$/RRPower$
+	}
+	MODULE
+	{
+		name = ProcessController
+		resource = _ECHeatedMetalRemelter
+		title = Metal Remelter
+		Tag = RR
+		capacity = 1
+		@capacity *= #$/RRPower$
+	}
 	
 	// = = RR Default Splitters = =
 	
@@ -515,6 +533,30 @@
 				// id_value = _LeadExtractor
 			// }
 		// }
+		SETUP
+		{
+			name = Metals Smelter
+			desc = Smelt <b>Metals</b> from <b>MetallicOre</b> and <b>Hydrogen</b>.
+			tech = advScienceTech
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _ECHeatedMetalSmelter
+			}
+		}
+		SETUP
+		{
+			name = Metals Remelter
+			desc = Recycle <b>ScrapMetal</b> into <b>Metals</b>.
+			tech = advScienceTech
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _ECHeatedMetalRemelter
+			}
+		}
 		
 		// = = RR Default Splitters = =
 		

--- a/GameData/RationalResourcesKerbalism/Stock_ConvertOTrons.cfg
+++ b/GameData/RationalResourcesKerbalism/Stock_ConvertOTrons.cfg
@@ -86,6 +86,24 @@
 	//	capacity = 1
 	//	@capacity *= #$/RRPower$
 	// }
+	MODULE
+	{
+		name = ProcessController
+		resource = _ECHeatedMetalSmelter
+		title = Metal Smelter
+		Tag = RR
+		capacity = 1
+		@capacity *= #$/RRPower$
+	}
+	MODULE
+	{
+		name = ProcessController
+		resource = _ECHeatedMetalRemelter
+		title = Metal Remelter
+		Tag = RR
+		capacity = 1
+		@capacity *= #$/RRPower$
+	}
 	
 	// = = RR Default Splitters = =
 	
@@ -263,6 +281,30 @@
 				// id_value = _LeadExtractor
 			// }
 		// }
+		SETUP
+		{
+			name = Metals Smelter
+			desc = Smelt <b>Metals</b> from <b>MetallicOre</b> and <b>Hydrogen</b>.
+			tech = advScienceTech
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _ECHeatedMetalSmelter
+			}
+		}
+		SETUP
+		{
+			name = Metals Remelter
+			desc = Recycle <b>ScrapMetal</b> into <b>Metals</b>.
+			tech = advScienceTech
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _ECHeatedMetalRemelter
+			}
+		}
 		SETUP
 		{
 			name = Splitter (Alumina)

--- a/GameData/RationalResourcesKerbalism/Stock_ConvertOTrons.cfg
+++ b/GameData/RationalResourcesKerbalism/Stock_ConvertOTrons.cfg
@@ -95,15 +95,6 @@
 		capacity = 1
 		@capacity *= #$/RRPower$
 	}
-	MODULE
-	{
-		name = ProcessController
-		resource = _ECHeatedMetalRemelter
-		title = Metal Remelter
-		Tag = RR
-		capacity = 1
-		@capacity *= #$/RRPower$
-	}
 	
 	// = = RR Default Splitters = =
 	
@@ -291,18 +282,6 @@
 				type = ProcessController
 				id_field = resource
 				id_value = _ECHeatedMetalSmelter
-			}
-		}
-		SETUP
-		{
-			name = Metals Remelter
-			desc = Recycle <b>ScrapMetal</b> into <b>Metals</b>.
-			tech = advScienceTech
-			MODULE
-			{
-				type = ProcessController
-				id_field = resource
-				id_value = _ECHeatedMetalRemelter
 			}
 		}
 		SETUP


### PR DESCRIPTION
This pull request adds kerbalism processes for manufacture of Metals and is part of larger [effort to bring RR and Extra-planetary Launchpads](https://github.com/VeronikaKerman/RationalResources/projects/1) inter-operable using (Kerbal)Ism.

Metal was renamed to Metals,
MetalOre was renamed to MetallicOre, because the later are part of CRP and plays nice with Kerbalism.

HydratesSplitter was re-balanced with 46% MetallicOre and 46% Water by mass, not sure if that is intended, but seems to match Limonite. (Ar, Xe retained, O2 reduced)

MetallicOre smelting process was added, using Hydrogen, where EL used LiquidFuel. There is also few percent process loss compared to ideal Hematite.

B9 and PP tank switchers were changed to use the CRP resources, and the the volume changed based of 5 vs 1 liters per unit of the new resources.

None of the new processes has balanced Electricity usage yet.
Neither are the volumes of the fuel tanks consistent.