### PR TITLE
Rebalance Procedural Parts tanks

### DIFF
--- a/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
@@ -170,7 +170,7 @@
 		{
 			name = LqdHydrogen
 			dryDensity = 0.1089
-			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
+			// handled by stock smurff
 			costMultiplier = 1.0
 			RESOURCE 
 			{
@@ -182,7 +182,7 @@
 		{
 			name = Hydrolox
 			dryDensity = 0.1089
-			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
+			// handled by stock smurff
 			costMultiplier = 1.0
 			RESOURCE 
 			{
@@ -212,7 +212,7 @@
 		{
 			name = Methalox
 			dryDensity = 0.1089
-			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
+			// too complicated to smurff
 			costMultiplier = 1.0
 			RESOURCE 
 			{

--- a/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
@@ -104,6 +104,7 @@
 	// conert everything else into unitsPerKL
 	// which should be in 869-871 range for vol1 resources
 	// apply smurff coefficient to dryDensity
+	// comment tons per 8kL
 	@description ^= :$: <br><#4FBBFF>Rational Resources.</color>
 	@MODULE[TankContentSwitcher]
 	{
@@ -138,6 +139,7 @@
 			{
 				name = LqdAmmonia
 				unitsPerKL = 946.547
+				// 6.1t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -150,6 +152,7 @@
 			{
 				name = LqdCO2
 				unitsPerKL = 872
+				// 10t
 			}
 		}
 		TANK_TYPE_OPTION:NEEDS[!CryoTanks]
@@ -191,6 +194,7 @@
 			{
 				name = LqdMethane
 				unitsPerKL = 872
+				// 3.4t
 			}
 		}
 		TANK_TYPE_OPTION:NEEDS[!CryoTanks]
@@ -220,6 +224,7 @@
 			{
 				name = LqdNitrogen
 				unitsPerKL = 872
+				// 6.6t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -232,6 +237,7 @@
 			{
 				name = LqdOxygen
 				unitsPerKL = 872
+				// 9.13t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -244,6 +250,7 @@
 			{
 				name = Water
 				unitsPerKL = 872
+				// 8.4t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -256,6 +263,7 @@
 			{
 				name = LqdCO
 				unitsPerKL = 872
+				// 6.7t
 			}
 		}
 	}
@@ -263,6 +271,7 @@
 @PART[proceduralTankOre]:NEEDS[ProceduralParts]
 {
 	@description ^= :$: <br><#4FBBFF>Rational Resources.</color>
+	// comment tons per 6420 l
 	@MODULE[TankContentSwitcher]
 	{
 		@TANK_TYPE_OPTION[Ore]
@@ -283,6 +292,9 @@
 			{
 				name = MetallicOre
 				unitsPerKL = 700
+				// 35.3t
+				unitsPerKL = 615
+				// 31t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -294,7 +306,10 @@
 			RESOURCE
 			{
 				name = Metals
-				unitsPerKL = 700
+				//unitsPerKL = 700
+				// 50t
+				unitsPerKL = 434
+				// 31t
 			}
 		}
 		// TANK_TYPE_OPTION
@@ -319,6 +334,7 @@
 			{
 				name = Alumina
 				unitsPerKL = 700
+				// 25.6t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -331,6 +347,7 @@
 			{
 				name = Aluminium
 				unitsPerKL = 700
+				// 17.8t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -343,6 +360,7 @@
 			{
 				name = Carbon
 				unitsPerKL = 700
+				// 13.5t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -355,6 +373,7 @@
 			{
 				name = ExoticMinerals
 				unitsPerKL = 700
+				// 16t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -367,6 +386,7 @@
 			{
 				name = Hydrates
 				unitsPerKL = 700
+				// 9.6t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -379,6 +399,7 @@
 			{
 				name = Lithium
 				unitsPerKL = 700
+				// 3.4t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -390,7 +411,10 @@
 			RESOURCE 
 			{
 				name = Monazite
-				unitsPerKL = 700
+				//unitsPerKL = 700
+				// 32.1t
+				unitsPerKL = 675
+				// 31t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -402,7 +426,10 @@
 			RESOURCE 
 			{
 				name = RareMetals
-				unitsPerKL = 700
+				//unitsPerKL = 700
+				// 50.1t
+				unitsPerKL = 433
+				// 31t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -415,6 +442,7 @@
 			{
 				name = Rock
 				unitsPerKL = 700
+				// 16t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -427,6 +455,7 @@
 			{
 				name = Silicates
 				unitsPerKL = 700
+				// 16t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -439,6 +468,7 @@
 			{
 				name = Spodumene
 				unitsPerKL = 700
+				// 19.9t
 			}
 		}
 		TANK_TYPE_OPTION
@@ -463,6 +493,7 @@
 			{
 				name = Silicon
 				unitsPerKL = 700
+				// 15t
 			}
 		}
 	}

--- a/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
@@ -279,6 +279,48 @@
 		}
 	}
 }
+
+@PART[proceduralTankLiquid]:NEEDS[ProceduralParts]:AFTER[CryoTanks]
+{
+	@MODULE[ModuleCryoTank]
+	{
+		// CoolingCost in Ec per 1000 units per second
+		// BoiloffRate in % per hr
+		// Hydrogen: -253 0.05  0.05
+		BOILOFFCONFIG
+		{
+			FuelName = LqdNitrogen // -196
+			BoiloffRate = 0.04
+			CoolingCost = 0.03
+		}
+		BOILOFFCONFIG
+		{
+			FuelName = LqdCO // -192
+			BoiloffRate = 0.04
+			CoolingCost = 0.04
+		}
+		BOILOFFCONFIG
+		{
+			FuelName = LqdOxygen // -183
+			BoiloffRate = 0.04
+			CoolingCost = 0.03
+		}
+		// Methane:  -161 0.005 0.02
+		BOILOFFCONFIG
+		{
+			FuelName = LqdCO2 // -78.5 (?)
+			BoiloffRate = 0.005
+			CoolingCost = 0.015
+		}
+		BOILOFFCONFIG
+		{
+			FuelName = LqdAmmonia // -35.5
+			BoiloffRate = 0.0035
+			CoolingCost = 0.010
+		}
+	}
+}
+
 @PART[proceduralTankOre]:NEEDS[ProceduralParts]
 {
 	@description ^= :$: <br><#4FBBFF>Rational Resources.</color>

--- a/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
@@ -52,6 +52,17 @@
 		}
 		TANK_TYPE_OPTION
 		{
+			name = Deuterium
+			dryDensity = 0.2068
+			costMultiplier = 1.0
+			RESOURCE 
+			{
+				name = Deuterium
+				unitsPerT = 700000 // 50
+			}
+		}
+		TANK_TYPE_OPTION
+		{
 			name = Methane
 			dryDensity = 0.2068
 			costMultiplier = 1.0

--- a/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/ProceduralTanks.cfg
@@ -9,6 +9,7 @@
 		{
 			name = ArgonGas
 			dryDensity = 0.2068 // try to match NFP "ARG-2M" Argon Tank
+			// (todo) @dryDensity /= #$@SMURFFCONFIG/argonfactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
@@ -82,11 +83,27 @@
 				unitsPerT = 700000 // 50
 			}
 		}
+		TANK_TYPE_OPTION
+		{
+			name = CarbonMonoxide
+			dryDensity = 0.2068
+			costMultiplier = 1.0
+			RESOURCE 
+			{
+				name = CarbonMonoxide
+				unitsPerT = 700000 // 50
+			}
+		}
 	}
 }
 
 @PART[proceduralTankLiquid]:NEEDS[ProceduralParts]
 {
+	// SMURFF: Mixed,LiquidFuel,Oxidizer,LqdHydrogen,XenonGas,Ore
+	// CryoTanks: LqdHydrogen,HydroOxi,MethaOxi
+	// conert everything else into unitsPerKL
+	// which should be in 869-871 range for vol1 resources
+	// apply smurff coefficient to dryDensity
 	@description ^= :$: <br><#4FBBFF>Rational Resources.</color>
 	@MODULE[TankContentSwitcher]
 	{
@@ -115,28 +132,31 @@
 		{
 			name = LqdAmmonia
 			dryDensity = 0.1089
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = LqdAmmonia
-				unitsPerT = 8000 // 5
+				unitsPerKL = 946.547
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = LqdCO2
 			dryDensity = 0.1089
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = LqdCO2
-				unitsPerT = 8000 // 5
+				unitsPerKL = 872
 			}
 		}
 		TANK_TYPE_OPTION:NEEDS[!CryoTanks]
 		{
 			name = LqdHydrogen
 			dryDensity = 0.1089
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
@@ -148,6 +168,7 @@
 		{
 			name = Hydrolox
 			dryDensity = 0.1089
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
@@ -164,17 +185,19 @@
 		{
 			name = LqdMethane
 			dryDensity = 0.1089
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = LqdMethane
-				unitsPerT = 8000 // 5
+				unitsPerKL = 872
 			}
 		}
 		TANK_TYPE_OPTION:NEEDS[!CryoTanks]
 		{
 			name = Methalox
 			dryDensity = 0.1089
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
@@ -191,33 +214,48 @@
 		{
 			name = LqdNitrogen
 			dryDensity = 0.1089
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = LqdNitrogen
-				unitsPerT = 8000 // 5
+				unitsPerKL = 872
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = LqdOxygen
 			dryDensity = 0.1089
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = LqdOxygen
-				unitsPerT = 8000 // 5
+				unitsPerKL = 872
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = Water
 			dryDensity = 0.1089
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = Water
-				unitsPerT = 8000 // 5
+				unitsPerKL = 872
+			}
+		}
+		TANK_TYPE_OPTION
+		{
+			name = LqdCO
+			dryDensity = 0.1089
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/lfofactor$
+			costMultiplier = 1.0
+			RESOURCE 
+			{
+				name = LqdCO
+				unitsPerKL = 872
 			}
 		}
 	}
@@ -231,151 +269,200 @@
 		{
 			@RESOURCE[Ore]
 			{
-				!unitsPerKL = 139.664
-				unitsPerT = 320
+				// !unitsPerKL = 139.664
+				// unitsPerT = 320
 			}
 		}
-		TANK_TYPE_OPTION:NEEDS[!Kerbalism]
+		TANK_TYPE_OPTION
 		{
-			name = MetalOre
-			dryDensity = 0.1089
+			name = MetallicOre
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
-			RESOURCE 
+			RESOURCE
 			{
-				name = MetalOre
-				unitsPerT = 320 // 0.2
+				name = MetallicOre
+				unitsPerKL = 700
 			}
 		}
-		TANK_TYPE_OPTION:NEEDS[!Kerbalism]
+		TANK_TYPE_OPTION
 		{
-			name = Metal
-			dryDensity = 0.1089
+			name = Metals
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
-			RESOURCE 
+			RESOURCE
 			{
-				name = Metal
-				unitsPerT = 1600 // 1
+				name = Metals
+				unitsPerKL = 700
 			}
 		}
 		// TANK_TYPE_OPTION
 		// {
 			// name = RocketParts
-			// dryDensity = 0.1089
+			// dryDensity = 0.1206
+			// @dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			// costMultiplier = 1.0
 			// RESOURCE 
 			// {
 				// name = RocketParts
-				// unitsPerT = 1600 // 1
+				// unitsPerKL = 135 // 5
 			// }
 		// }
 		TANK_TYPE_OPTION
 		{
 			name = Alumina
-			dryDensity = 0.1089
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = Alumina
-				unitsPerT = 1600 // 1
+				unitsPerKL = 700
+			}
+		}
+		TANK_TYPE_OPTION
+		{
+			name = Aluminium
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
+			costMultiplier = 1.0
+			RESOURCE 
+			{
+				name = Aluminium
+				unitsPerKL = 700
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = Carbon
-			dryDensity = 0.1089
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = Carbon
-				unitsPerT = 1600 // 1
+				unitsPerKL = 700
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = ExoticMinerals
-			dryDensity = 0.1089
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = ExoticMinerals
-				unitsPerT = 1600 // 1
+				unitsPerKL = 700
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = Hydrates
-			dryDensity = 0.1089
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = Hydrates
-				unitsPerT = 1600 // 1
+				unitsPerKL = 700
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = Lithium
-			dryDensity = 0.1089
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = Lithium
-				unitsPerT = 1600 // 1
+				unitsPerKL = 700
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = Monazite
-			dryDensity = 0.1089
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = Monazite
-				unitsPerT = 1600 // 1
+				unitsPerKL = 700
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = RareMetals
-			dryDensity = 0.1089
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = RareMetals
-				unitsPerT = 1600 // 1
+				unitsPerKL = 700
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = Rock
-			dryDensity = 0.1089
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = Rock
-				unitsPerT = 1600 // 1
+				unitsPerKL = 700
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = Silicates
-			dryDensity = 0.1089
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = Silicates
-				unitsPerT = 8000 // 5
+				unitsPerKL = 700
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = Spodumene
-			dryDensity = 0.1089
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
 			costMultiplier = 1.0
 			RESOURCE 
 			{
 				name = Spodumene
-				unitsPerT = 8000 // 5
+				unitsPerKL = 700
+			}
+		}
+		TANK_TYPE_OPTION
+		{
+			name = Phosphorus
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
+			costMultiplier = 1.0
+			RESOURCE 
+			{
+				name = Phosphorus
+				unitsPerKL = 140 // 5
+			}
+		}
+		TANK_TYPE_OPTION
+		{
+			name = Silicon
+			dryDensity = 0.1206
+			@dryDensity:NEEDS[SMURFF] /= #$@SMURFFCONFIG/orefactor$
+			costMultiplier = 1.0
+			RESOURCE 
+			{
+				name = Silicon
+				unitsPerKL = 700
 			}
 		}
 	}


### PR DESCRIPTION
* use unitsPerKL for greater consistency (touches #22)
* reduce capacity of very dense resources (MetallicOre, Metals, Monazite, RareMetals)
* support SMURFF
* add deuterium gas (reported missing in forum)
* add a stockalike boiloff (which is too low and does not respect heat radiation)

Thank you for reading 3!!!