### PR TITLE
Fix broken TACLS interaction with SSPXR

### DIFF
--- a/Extras/RationalResourcesTACLS/RR_TACLS_SSPXr.cfg
+++ b/Extras/RationalResourcesTACLS/RR_TACLS_SSPXr.cfg
@@ -1,4 +1,19 @@
-@SSPXR-ROOT-TAC*:NEEDS[TacLifeSupport]:BEFORE[StationPartsExpansionRedux]
+@SSPXR-ROOT-TACCREWBASIC:NEEDS[TacLifeSupport]:BEFORE[StationPartsExpansionRedux]
+{
+	// Carbon Extractor
+	@MODULE[TacGenericConverter]:HAS[@INPUT_RESOURCE:HAS[#ResourceName[CarbonDioxide]],@OUTPUT_RESOURCE:HAS[#ResourceName[Waste]],!OUTPUT_RESOURCE:HAS[#ResourceName[Water]]]
+	{
+		-OUTPUT_RESOURCE:HAS[#ResourceName[Waste]] {}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Carbon
+			Ratio = 4.31845178e-7
+			DumpExcess = true
+		}
+	}
+}
+
+@SSPXR-ROOT-TACCREWPLUS:NEEDS[TacLifeSupport]:BEFORE[StationPartsExpansionRedux]
 {
 	// Sabatier Recyclers
 	@MODULE[TacGenericConverter]:HAS[@INPUT_RESOURCE:HAS[#ResourceName[Water]],@INPUT_RESOURCE:HAS[#ResourceName[CarbonDioxide]]]
@@ -25,16 +40,16 @@
 			DumpExcess = true
 		}
 	}
-	
-	// Carbon Extractor
-	@MODULE[TacGenericConverter]:HAS[@INPUT_RESOURCE:HAS[#ResourceName[CarbonDioxide]],@OUTPUT_RESOURCE:HAS[#ResourceName[Waste]],!OUTPUT_RESOURCE:HAS[#ResourceName[Water]]]
+	//Water Splitter hydrogen ratio fix following suit with the other patch to the TACLS Water Splitter in RR_TACLS.cfg
+	@MODULE[TacGenericConverter]:HAS[@INPUT_RESOURCE:HAS[#ResourceName[Water]],@OUTPUT_RESOURCE:HAS[#ResourceName[Oxygen]],@OUTPUT_RESOURCE:HAS[#ResourceName[Hydrogen]]]
 	{
-		-OUTPUT_RESOURCE:HAS[#ResourceName[Waste]] {}
-		OUTPUT_RESOURCE
+		@OUTPUT_RESOURCE:HAS[#ResourceName[Hydrogen]]
 		{
-			ResourceName = Carbon
-			Ratio = 4.31845178e-7
-			DumpExcess = true
+			@Ratio = 0.0033862111
 		}
 	}
 }
+
+
+
+


### PR DESCRIPTION
MM wasn't recognizing the wildcard in the header node so it was split into the two separate, relevant nodes. 

Also included is the balance to the water splitter module's hydrogen gas output as taken from RR_TACLS.cfg, as SSPXR already has the water splitter output hydrogen instead of Waste.