### PR TITLE
Fix table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following templates have been made available. **Unique** entries are templat
 The Star series templates apply resource bands in the vein of [Stellar Populations](https://en.wikipedia.org/wiki/Stellar_population), automatically making them all viable as mining destinations for interstellar vessels. Population 1 is current and rich with many common resources while the later ones retreat in time to a younger universe and become increasingly abundant in only Hydrogen and CRP's Antimatter or Classic Stock's Graviolium.
 
 | Surface | Ocean | Atmosphere | Exo (Trace) |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | Rock | Terra | Default (CO2-rich) | Rock |
 | Silica | Nitrogen | Terra |  Ice |
 | Vulcan | Methane | Vulcan |  None |


### PR DESCRIPTION
Hi @JadeOfMaar, I noticed this while working on KSP-CKAN/NetKAN#9095.

## Problem

The table in the README looks like this:

![image](https://user-images.githubusercontent.com/1559108/165882618-2ef0a465-efeb-4619-b976-580fb131588f.png)

## Cause

There's an extra cell in the header separator row.

## Changes

Now every row has four cells, so the table renders correctly.
