### PR TITLE
added flowmode to box_flat_* converter outputs

### DIFF
--- a/GameData/RationalResourcesParts/DemoParts/Boxes/B_blue_flat.cfg
+++ b/GameData/RationalResourcesParts/DemoParts/Boxes/B_blue_flat.cfg
@@ -83,6 +83,7 @@ PART
 		{
 			ResourceName = LqdAmmonia
 			Ratio = 0.24
+			FlowMode = STAGE_PRIORITY_FLOW
 			DumpExcess = false
 		}
 	}

--- a/GameData/RationalResourcesParts/DemoParts/Boxes/B_red_flat.cfg
+++ b/GameData/RationalResourcesParts/DemoParts/Boxes/B_red_flat.cfg
@@ -97,6 +97,7 @@ PART
 		{
 			ResourceName = Ammonia
 			Ratio = 221.47
+			FlowMode = STAGE_PRIORITY_FLOW
 			DumpExcess = false
 		}
 	}


### PR DESCRIPTION
The freezers were not pushing their outputs to available tanks, only when directly node-attached.
Added FlowMode = STAGE_PRIORITY_FLOW to the converter templates.