### PR TITLE
Add support for Wild Blue Industry parts

### DIFF
--- a/Extras/RationalResourcesELUtilities/RR_EL-CRP.cfg
+++ b/Extras/RationalResourcesELUtilities/RR_EL-CRP.cfg
@@ -79,7 +79,7 @@
 }
 
 // Patch anything that tanks these resources
-@PART:HAS[@RESOURCE[Metal*]]:NEEDS[communityResourcePack,Launchpad]
+@PART:HAS[@RESOURCE[Metal*]]:NEEDS[communityResourcePack,Launchpad]:FINAL
 {
 	@RESOURCE[Metal]
 	{
@@ -95,7 +95,7 @@
 	}
 }
 
-@PART:HAS[@MODULE[ModuleResourceConverter]]:NEEDS[communityResourcePack,Launchpad]
+@PART:HAS[@MODULE[ModuleResourceConverter]]:NEEDS[communityResourcePack,Launchpad]:FINAL
 {
 	@MODULE[ModuleResourceConverter],*
 	{
@@ -114,5 +114,66 @@
 			@ResourceName = MetallicOre
 			@Ratio *= 4.7272
 		}
+	}
+}
+
+@PATH_INDUSTRY:HAS[@RESOURCE[Metal*]]:NEEDS[CommunityResourcePack,Launchpad,Pathfinder]:FINAL
+{
+	@RESOURCE[Metal]
+	{
+		@name = Metals
+		@amount *= 5 // #$@RESOURCE_DEFINITION[Metal]/volume$
+		@maxAmount *= 5 // #$@RESOURCE_DEFINITION[Metal]/volume$
+	}
+	@RESOURCE[MetalOre]
+	{
+		@name = MetallicOre
+		@amount *= 5 // #$@RESOURCE_DEFINITION[MetalOre]/volume$
+		@maxAmount *= 5 // #$@RESOURCE_DEFINITION[MetalOre]/volume$
+	}
+}
+
+@PATH_INDUSTRY:HAS[@MODULE[ModuleResourceConverter]]:NEEDS[CommunityResourcePack,Launchpad,Pathfinder]:FINAL
+{
+	@MODULE[ModuleResourceConverter],*
+	{
+		@INPUT_RESOURCE:HAS[#ResourceName[Metal]]
+		{
+			@ResourceName = Metals
+			@Ratio *= 5
+		}
+		@OUTPUT_RESOURCE:HAS[#ResourceName[Metal]]
+		{
+			@ResourceName = Metals
+			@Ratio *= 5
+		}
+		@INPUT_RESOURCE:HAS[#ResourceName[MetalOre]]
+		{
+			@ResourceName = MetallicOre
+			@Ratio *= 4.7272
+		}
+	}
+}
+
+@OMNICONVERTER:HAS[@INPUT_RESOURCE:HAS[#ResourceName[Metal*]]]:NEEDS[WildBlueTools,CommunityResourcePack]:FINAL
+{
+	@INPUT_RESOURCE:HAS[#ResourceName[Metal]]
+	{
+		@ResourceName = Metals
+		@Ratio *= 5
+	}
+	@INPUT_RESOURCE:HAS[#ResourceName[MetalOre]]
+	{
+		@ResourceName = MetallicOre
+		@Ratio *= 4.7272
+	}
+}
+
+@OMNICONVERTER:HAS[@OUTPUT_RESOURCE:HAS[#ResourceName[Metal*]]]:NEEDS[WildBlueTools,CommunityResourcePack]:FINAL
+{
+	@OUTPUT_RESOURCE:HAS[#ResourceName[Metal]]
+	{
+		@ResourceName = Metals
+		@Ratio *= 5
 	}
 }


### PR DESCRIPTION
Pathfinder parts can be reconfigured in the field to become an EL part.

Also adding FINAL keyword because some parts only add EL functionality thru a patch if EL is present. If we run before them, our tweaks don't get applied to them.