### PR TITLE
Add support for Wild Blue Industry tanks

### DIFF
--- a/Extras/RationalResourcesELUtilities/RR_EL-CRP.cfg
+++ b/Extras/RationalResourcesELUtilities/RR_EL-CRP.cfg
@@ -95,6 +95,23 @@
 	}
 }
 
+// Wild Blue Industries (Pathfinder, DSEV, Buffalo, etc.) tanks
+@STORAGE_TEMPLATE:NEEDS[WildBlueTools,CommunityResourcePack]:FOR[zRationalResources]
+{
+	@RESOURCE[Metal]
+	{
+		@name = Metals
+		@amount *= 5 // #$@RESOURCE_DEFINITION[Metal]/volume$
+		@maxAmount *= 5 // #$@RESOURCE_DEFINITION[Metal]/volume$
+	}
+	@RESOURCE[MetalOre]
+	{
+		@name = MetallicOre
+		@amount *= 5 // #$@RESOURCE_DEFINITION[MetalOre]/volume$
+		@maxAmount *= 5 // #$@RESOURCE_DEFINITION[MetalOre]/volume$
+	}
+}
+
 @PART:HAS[@MODULE[ModuleResourceConverter]]:NEEDS[communityResourcePack,Launchpad]:FOR[zRationalResources] 
 {
 	@MODULE[ModuleResourceConverter],*

--- a/Extras/RationalResourcesELUtilities/RR_EL-CRP.cfg
+++ b/Extras/RationalResourcesELUtilities/RR_EL-CRP.cfg
@@ -79,7 +79,7 @@
 }
 
 // Patch anything that tanks these resources
-@PART:HAS[@RESOURCE[Metal*]]:NEEDS[communityResourcePack,Launchpad]:FOR[zRationalResources] 
+@PART:HAS[@RESOURCE[Metal*]]:NEEDS[communityResourcePack,Launchpad]:FOR[zRationalResources]
 {
 	@RESOURCE[Metal]
 	{
@@ -117,7 +117,7 @@
 	}
 }
 
-@PATH_INDUSTRY:HAS[@RESOURCE[Metal*]]:NEEDS[CommunityResourcePack,Launchpad,Pathfinder]:FOR[zRationalResources] 
+@PATH_INDUSTRY:HAS[@RESOURCE[Metal*]]:NEEDS[CommunityResourcePack,Launchpad,Pathfinder]:FOR[zRationalResources]
 {
 	@RESOURCE[Metal]
 	{
@@ -133,7 +133,7 @@
 	}
 }
 
-@PATH_INDUSTRY:HAS[@MODULE[ModuleResourceConverter]]:NEEDS[CommunityResourcePack,Launchpad,Pathfinder]:FOR[zRationalResources] 
+@PATH_INDUSTRY:HAS[@MODULE[ModuleResourceConverter]]:NEEDS[CommunityResourcePack,Launchpad,Pathfinder]:FOR[zRationalResources]
 {
 	@MODULE[ModuleResourceConverter],*
 	{
@@ -155,7 +155,7 @@
 	}
 }
 
-@OMNICONVERTER:HAS[@INPUT_RESOURCE:HAS[#ResourceName[Metal*]]]:NEEDS[WildBlueTools,CommunityResourcePack]:FOR[zRationalResources] 
+@OMNICONVERTER:HAS[@INPUT_RESOURCE:HAS[#ResourceName[Metal*]]]:NEEDS[WildBlueTools,CommunityResourcePack]:FOR[zRationalResources]
 {
 	@INPUT_RESOURCE:HAS[#ResourceName[Metal]]
 	{
@@ -169,7 +169,7 @@
 	}
 }
 
-@OMNICONVERTER:HAS[@OUTPUT_RESOURCE:HAS[#ResourceName[Metal*]]]:NEEDS[WildBlueTools,CommunityResourcePack]:FOR[zRationalResources] 
+@OMNICONVERTER:HAS[@OUTPUT_RESOURCE:HAS[#ResourceName[Metal*]]]:NEEDS[WildBlueTools,CommunityResourcePack]:FOR[zRationalResources]
 {
 	@OUTPUT_RESOURCE:HAS[#ResourceName[Metal]]
 	{

--- a/GameData/RationalResourcesCompanion/CRP/OmniconvertersCRP.cfg
+++ b/GameData/RationalResourcesCompanion/CRP/OmniconvertersCRP.cfg
@@ -2320,6 +2320,38 @@ OMNICONVERTER:NEEDS[WildBlueTools,CommunityResourcePack,!ClassicStock]
 	}
 }
 
+STORAGE_TEMPLATE:NEEDS[WildBlueTools,CommunityResourcePack,!ClassicStock]
+{
+	name = Konstruction (RR Equipment)
+	shortName = Konstruction (RR Equipment)
+	logoPanel = WildBlueIndustries/000WildBlueTools/Decals/Factory_ClockWorks
+	glowPanel = WildBlueIndustries/000WildBlueTools/Decals/Factory_ClockWorksGlow
+	TechRequired = advScienceTech
+	description = This kit stores the resources needed to create equipment. Equipment is used to outfit your modules.
+	templateTags = stowage
+
+	RESOURCE
+	{
+		name = Minerals
+		amount = 2333
+		maxAmount = 2333
+	}
+
+	RESOURCE
+	{
+		name = Metals
+		amount = 2333
+		maxAmount = 2333
+	}
+
+	RESOURCE
+	{
+		name = Equipment
+		amount = 933
+		maxAmount = 933
+	}
+}
+
 OMNICONVERTER:NEEDS[WildBlueTools,CommunityResourcePack]
 {
 	templateTags = rrconv


### PR DESCRIPTION
My previous pull request https://github.com/JadeOfMaar/RationalResources/pull/55 covered all the converters but not the tanks.

Also added a storage template for our custom RR equipment recipe just like the Wild Blue equipment recipe.
https://github.com/Angel-125/WildBlueTools/blob/master/GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage/KonstructionEquipment.txt

Added a new one instead of patching the existing one because the old one based on Ore is still viable. It just requires precious Ore.

Not adding the same storage templates for other RR OmniConverter recipes because they didn't do it for classic stock recipes neither. What they did instead is to add OmniStorage allowing people to build their own combo storage for all their custom use cases. So I made a pull request to make that available to both CRP and classic stock. https://github.com/Angel-125/WildBlueTools/pull/44 It would then pick up all of our custom resource changes without needed more custom formulas.