### PR TITLE
Rebalance costs and entrycosts of several new parts

### DIFF
--- a/GameData/RationalResourcesParts/Parts/CryoTanks.cfg
+++ b/GameData/RationalResourcesParts/Parts/CryoTanks.cfg
@@ -6,8 +6,8 @@ PART
 	rescaleFactor = 1
 	node_attach = 0.0, 0.0, 0.625, 0.0, 0.0, -1.0, 1
 	TechRequired = fuelSystems
-	entryCost = 450
-	cost = 180
+	entryCost = 3000
+	cost = 440
 	category = FuelTank
 	subcategory = 0
 	title = RR CryoTank 1.25m
@@ -55,8 +55,8 @@ PART
 	@title = RR CryoTank 2.5m
 	@node_attach = 0.0, 0.0, 1.25, 0.0, 0.0, -1.0, 1
  	@TechRequired = advFuelSystems
-  	@entryCost *= 4
-	@cost *= 4
+  	@entryCost *= 3
+	@cost *= 6
 	@mass != 2
 	@refVolume = 2880
 	@NODE,*
@@ -74,8 +74,8 @@ PART
 	@title = RR CryoTank 3.75m
 	@node_attach = 0.0, 0.0, 1.875, 0.0, 0.0, -1.0, 1
  	@TechRequired = largeVolumeContainment
-  	@entryCost *= 9
-	@cost *= 9
+  	@entryCost *= 10
+	@cost *= 14
 	@mass != 3
 	@refVolume = 9720
 	@NODE,*
@@ -94,8 +94,8 @@ PART
 	@title = RR CryoTank 5m
 	@node_attach = 0.0, 0.0, 2.5, 0.0, 0.0, -1.0, 1
  	@TechRequired = highPerformanceFuelSystems
-  	@entryCost *= 16
-	@cost *= 16
+  	@entryCost *= 20
+	@cost *= 30
 	@mass != 4
 	@refVolume = 23040
 	@NODE,*

--- a/GameData/RationalResourcesParts/Parts/GasTanks.cfg
+++ b/GameData/RationalResourcesParts/Parts/GasTanks.cfg
@@ -6,8 +6,8 @@ PART
 	rescaleFactor = 1
 	node_attach = 0.0, 0.0, 0.625, 0.0, 0.0, -1.0, 1
 	TechRequired = fuelSystems
-	entryCost = 450
-	cost = 180
+	entryCost = 3000
+	cost = 440
 	category = FuelTank
 	subcategory = 0
 	title = RR Gas Cache Tank 1.25m
@@ -53,8 +53,8 @@ PART
 	@title = RR Gas Cache Tank 2.5m
 	@node_attach = 0.0, 0.0, 1.25, 0.0, 0.0, -1.0, 1
  	@TechRequired = advFuelSystems
-  	@entryCost *= 4
-	@cost *= 4
+  	@entryCost *= 2.5
+	@cost *= 5
 	@mass != 2
 	@refVolume = 412
 	@NODE,*
@@ -72,8 +72,8 @@ PART
 	@title = RR Gas Cache Tank 3.75m
 	@node_attach = 0.0, 0.0, 1.875, 0.0, 0.0, -1.0, 1
  	@TechRequired = largeVolumeContainment
-  	@entryCost *= 9
-	@cost *= 9
+  	@entryCost *= 7
+	@cost *= 12
 	@mass != 3
 	@refVolume = 1388
 	@NODE,*
@@ -92,8 +92,8 @@ PART
 	@title = RR Gas Cache Tank 5m
 	@node_attach = 0.0, 0.0, 2.5, 0.0, 0.0, -1.0, 1
 	@TechRequired = highPerformanceFuelSystems
- 	@entryCost *= 16
-	@cost *= 16
+ 	@entryCost *= 14
+	@cost *= 24
 	@mass != 4
 	@refVolume = 3290
 	@NODE,*

--- a/GameData/RationalResourcesParts/Parts/WrapperIntake.cfg
+++ b/GameData/RationalResourcesParts/Parts/WrapperIntake.cfg
@@ -6,8 +6,8 @@ PART
 	rescaleFactor = 1
 	node_attach = 0.0, 0.0, 0, 0.0, 0.0, -1.0, 1
 	TechRequired = aerodynamicSystems
-	entryCost = 620
-	cost = 220
+	entryCost = 6000
+	cost = 400
 	category = Utility
 	subcategory = 0
 	title = RR Wrapper Intake

--- a/GameData/RationalResourcesParts/Parts/WrapperRefinery.cfg
+++ b/GameData/RationalResourcesParts/Parts/WrapperRefinery.cfg
@@ -6,7 +6,7 @@ PART
 	rescaleFactor = 1
 	node_attach = 0.0, 0.0, 0, 0.0, 0.0, -1.0, 1
 	TechRequired = advScienceTech
-	entryCost = 1620
+	entryCost = 4000
 	cost = 1000
 	category = Utility
 	subcategory = 0

--- a/GameData/RationalResourcesParts/Parts/WrapperTanks.cfg
+++ b/GameData/RationalResourcesParts/Parts/WrapperTanks.cfg
@@ -6,8 +6,8 @@ PART
 	rescaleFactor = 1
 	node_attach = 0.0, 0.0, 0, 0.0, 0.0, -1.0, 1
 	TechRequired = advFuelSystems
-	entryCost = 450
-	cost = 180
+	entryCost = 5600
+	cost = 450
 	category = FuelTank
 	subcategory = 0
 	title = RR Wrapper Tank
@@ -84,8 +84,8 @@ PART
 	rescaleFactor = 1
 	node_attach = 0.0, 0.0, 0, 0.0, 0.0, -1.0, 1
 	TechRequired = advFuelSystems
-	entryCost = 450
-	cost = 180
+	entryCost = 5100
+	cost = 450
 	category = FuelTank
 	subcategory = 0
 	title = RR Wrapper Shroud Tank


### PR DESCRIPTION
Here's the cost PR I mentioned. My reasoning is as follows:

- Wrapper Intake cost from 220 to 400, above the stock mini intake but below the circular intake, since its intake area is between the two and it doubles as a harvester. Entrycost from 620 to 6000 with similar justification. Previously, both the price and entrycost were below the inferior small circular intake!

- Wrapper Refinery entrycost from 1620 to 4000, the same as the mini isru.

- wrapper tank cost from 180 to 450, roughly on par with stock tanks of similar volume, leaning higher for the convenient form factor. Entrycost from 450 to 5600 for wrappertank and 5100 for shroud wrappertank, roughly between the stock t800 and tx1800 to account for the max selectable volumes.

Cryotank and gas cache base costs changed from 180 cost and 450 entrycost to 440 cost, 3000 entrycost. 
Cryotank price scaling:
- 2.5:    x6 cost, x3 entrycost
- 3.75:   x14 cost, x10 entrycost
- 5.0:  x30 cost, x20 entrycost

gas cache price scaling:
- 2.5: x5 cost, x2.5 entrycost
- 3.75: x12 cost, x7 entrycost
- 5.0: x24 cost, x14 entrycost

Derived from squinting at stock fuel tanks, nertea cryotanks, and parts at similar tech nodes and picking numbers that felt right. Mostly vibes based. 
gas cache scales slower due to its lower utility compared to more common fuels.

Harvesters, scanners, boxed converters, etc. didn't seem too out of place and went untouched.

Overall, the original prices were considerably lower than equivalent stock parts and had to be raised.