### PR TITLE
Fixes to NTJ & Thermal Nozzle CRP Configs

### DIFF
--- a/Extras/RationalResourcesNuclearFamily/RR_NuclearFamily_CRP_Jets.cfg
+++ b/Extras/RationalResourcesNuclearFamily/RR_NuclearFamily_CRP_Jets.cfg
@@ -724,7 +724,7 @@
 		%primaryEngineModeDisplayName = RR_AtomicJet
 		@secondaryEngineID = LH2
 		%secondaryEngineModeDisplayName = RR_RedAgent
-		@MODULE[MultiModeEngine]
+		//@MODULE[MultiModeEngine] //Probably harmless?
 	}
 	
 	@MODULE[ModuleEnginesFX],0

--- a/Extras/RationalResourcesNuclearFamily/RR_NuclearFamily_CRP_ThermalNozzles.cfg
+++ b/Extras/RationalResourcesNuclearFamily/RR_NuclearFamily_CRP_ThermalNozzles.cfg
@@ -983,36 +983,39 @@
 	@RRLATN = Joined
 	@MODULE[ModuleEnginesFX],0
 	{
-		@maxThrust = #$/ThrustVacN2$
+		%engineID = IntakeAtm
 		!PROPELLANT,* {}
 		PROPELLANT
 		{
 			name = IntakeAtm
+			// ignoreForIsp = True
 			ratio = 1
 			DrawGauge = True
-			ignoreForThrustCurve = True
-			resourceFlowMode = STAGE_PRIORITY_FLOW
 		}
 		PROPELLANT
 		{
 			name = ThermalPower
-			ratio = 21.57219 // Nitrogen
-			@ratio *= #$/IspMult$
-			DrawGauge = True
+			ratio = 196.133
 			ignoreForIsp = True
+			DrawGauge = True
 			resourceFlowMode = STAGE_PRIORITY_FLOW
 		}
 		@atmosphereCurve
 		{
-			@key,0[1, ] = #$/IspVacN2$
-			@key,1[1, ] = #$/IspASLN2$
-			@key,2[1, ] = #$/Isp3rdN2$
+			!key,* = nope
+			key = 0 2000 0 0 
 		}
-		%useThrustCurve = True
-		%thrustCurve
+		@atmCurve
 		{
 			!key,* = nope
-			key = 0.1 0.1
+			key = 0 0.5
+			key = 1 1 0.45 0.45
+			key = 30 6 0 0
+		}
+		%useThrustCurve = True
+		thrustCurve
+		{
+			key = 0 0.25
 			key = 0.8 1 0 0
 		}
 	}

--- a/Extras/RationalResourcesNuclearFamily/RR_NuclearFamily_CRP_ThermalNozzles.cfg
+++ b/Extras/RationalResourcesNuclearFamily/RR_NuclearFamily_CRP_ThermalNozzles.cfg
@@ -591,60 +591,65 @@
 		%secondaryEngineModeDisplayName = RR_Closed
 	}
 	
-	// @MODULE[ModuleEnginesFX],0
-	// {
-		// @maxThrust = #$/ThrustVacN2$
-		// !PROPELLANT,* {}
-		// PROPELLANT
-		// {
-			// name = IntakeAtm
-			// ratio = 1
-			// DrawGauge = True
-			// ignoreForThrustCurve = True
-			// resourceFlowMode = STAGE_PRIORITY_FLOW
-		// }
-		// PROPELLANT
-		// {
-			// name = ThermalPower
-			// ratio = 21.57219 // Nitrogen
-			// @ratio *= #$/IspMult$
-			// DrawGauge = True
-			// ignoreForIsp = True
-			// resourceFlowMode = STAGE_PRIORITY_FLOW
-		// }
-		// @atmosphereCurve
-		// {
-			// @key,0[1, ] = #$/IspVacN2$
-			// @key,1[1, ] = #$/IspASLN2$
-			// @key,2[1, ] = #$/Isp3rdN2$
-		// }
-		// %useThrustCurve = True
-		// %thrustCurve
-		// {
-			// !key,* = nope
-			// key = 0.1 0.1
-			// key = 0.8 1 0 0
-		// }
-	// }
+	@MODULE[ModuleEnginesFX],0
+	{
+		%engineID = IntakeAtm
+	//	!PROPELLANT,* {}	//Dont want to Modify Airbreathing mode aside from adjusting its engineID to match MultiMode ID's
+	//	PROPELLANT
+	//	{
+	//		name = IntakeAtm
+	//		// ignoreForIsp = True
+	//		ratio = 1
+	//		DrawGauge = True
+	//	}
+	//	PROPELLANT
+	//	{
+	//		name = ThermalPower
+	//		ratio = 196.133
+	//		ignoreForIsp = True
+	//		DrawGauge = True
+	//		resourceFlowMode = STAGE_PRIORITY_FLOW
+	//	}
+	//	@atmosphereCurve
+	//	{
+	//		!key,* = nope
+	//		key = 0 2000 0 0 
+	//	}
+	//	@atmCurve
+	//	{
+	//		!key,* = nope
+	//		key = 0 0.5
+	//		key = 1 1 0.45 0.45
+	//		key = 30 6 0 0
+	//	}
+	//	%useThrustCurve = True
+	//	thrustCurve
+	//	{
+	//		key = 0 0.25
+	//		key = 0.8 1 0 0
+	//	}
+	}
 	
 	@MODULE[ModuleEnginesFX],1
 	{
 		%engineID = LqdCO2
-		@PROPELLANT,0
+		!PROPELLANT,* {}	//If we dont wipe out existing propellants, we might end up requiring oxidizer if the original engine config.
+		PROPELLANT,0
 		{
-			@name = LqdHydrogen
-			@ratio = 1
-			%DrawGauge = True
-			%ignoreForThrustCurve = True
-			%resourceFlowMode = STAGE_PRIORITY_FLOW
+			name = LqdHydrogen
+			ratio = 1
+			DrawGauge = True
+			ignoreForThrustCurve = True
+			resourceFlowMode = STAGE_PRIORITY_FLOW
 		}
-		%PROPELLANT[ThermalPower]
+		PROPELLANT
 		{
-			%ratio = 1.88149
-			@ratio *= #$/IspMult$
-			%DrawGauge = True
-			%ignoreForIsp = True
-			%resourceFlowMode = STAGE_PRIORITY_FLOW
+			name = ThermalPower
+			ratio = 1.88149
+			ratio *= #$/IspMult$
+			DrawGauge = True
+			IgnoreForIsp = True
+			resourceFlowMode = STAGE_PRIORITY_FLOW
 		}
 		@atmosphereCurve
 		{
@@ -992,7 +997,6 @@
 	@RRLATN = Joined
 	@MODULE[ModuleEnginesFX],0
 	{
-		%engineID = IntakeAtm
 		!PROPELLANT,* {}
 		PROPELLANT
 		{

--- a/Extras/RationalResourcesNuclearFamily/RR_NuclearFamily_CRP_ThermalNozzles.cfg
+++ b/Extras/RationalResourcesNuclearFamily/RR_NuclearFamily_CRP_ThermalNozzles.cfg
@@ -582,6 +582,14 @@
 	@ThrustVacH2O *= 1.78
 	ThrustASLH2O = #$ThrustVacH2O$
 	@ThrustASLH2O *= #$ThrustSLFraction$
+
+	@MODULE[MultiModeEngine]
+	{
+		@primaryEngineID = IntakeAtm
+		%primaryEngineModeDisplayName = RR_ThermalJet
+		@secondaryEngineID = LqdCO2
+		%secondaryEngineModeDisplayName = RR_Closed
+	}
 	
 	// @MODULE[ModuleEnginesFX],0
 	// {
@@ -621,6 +629,7 @@
 	
 	@MODULE[ModuleEnginesFX],1
 	{
+		%engineID = LqdCO2
 		@PROPELLANT,0
 		{
 			@name = LqdHydrogen


### PR DESCRIPTION
Thermal Nozzles were using an outdated clone of the patches used to allow airbreathing mode to inherit changes to the Closed Cycle. Performed a quick test with the changes using the ARI 73B engines from OPT and the behavior appeared to be correct.